### PR TITLE
Add patch for -as-needed flag in libtool

### DIFF
--- a/recipes/build-tools/libtool.recipe
+++ b/recipes/build-tools/libtool.recipe
@@ -24,3 +24,13 @@ class Recipe(recipe.Recipe):
         if os.path.exists(self.build_dir):
             shutil.rmtree(self.build_dir)
         super(recipe.Recipe, self).extract()
+
+    def compile(self):
+        super(recipe.Recipe, self).compile()
+
+        patch = 'libtool/0001-Fix--as-needed.patch'
+        if not os.path.isabs(patch):
+            patch = self.relative_path(patch)
+        shell.call('chmod u+w libltdl/config/ltmain.sh', self.build_dir)
+        shell.apply_patch(patch, self.build_dir, self.strip)
+

--- a/recipes/build-tools/libtool/0001-Fix--as-needed.patch
+++ b/recipes/build-tools/libtool/0001-Fix--as-needed.patch
@@ -1,0 +1,30 @@
+--- a/libltdl/config/ltmain.sh	2011-10-17 10:19:35.000000000 +0000
++++ b/tmp/ltmain.sh	2016-07-06 07:23:05.987964264 +0000
+@@ -5800,6 +5800,11 @@
+ 	arg=$func_stripname_result
+ 	;;
+ 
++      -Wl,--as-needed|-Wl,--no-as-needed)
++	deplibs="$deplibs $arg"
++	continue
++	;;
++
+       -Wl,*)
+ 	func_stripname '-Wl,' '' "$arg"
+ 	args=$func_stripname_result
+@@ -6160,6 +6165,15 @@
+ 	lib=
+ 	found=no
+ 	case $deplib in
++	-Wl,--as-needed|-Wl,--no-as-needed)
++	  if test "$linkmode,$pass" = "prog,link"; then
++	    compile_deplibs="$deplib $compile_deplibs"
++	    finalize_deplibs="$deplib $finalize_deplibs"
++	  else
++	    deplibs="$deplib $deplibs"
++	  fi
++	  continue
++	  ;;
+ 	-mt|-mthreads|-kthread|-Kthread|-pthread|-pthreads|--thread-safe \
+         |-threads|-fopenmp|-openmp|-mp|-xopenmp|-omp|-qsmp=*)
+ 	  if test "$linkmode,$pass" = "prog,link"; then


### PR DESCRIPTION
It was adding the as-needed flag at the end, when it needs to be before the libs to link
From https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=347650