### PR TITLE
Update gtk-sharp to version 2.12.45

### DIFF
--- a/recipes/gtk-sharp/gtk-sharp-2.0.recipe
+++ b/recipes/gtk-sharp/gtk-sharp-2.0.recipe
@@ -4,11 +4,11 @@ import os
 
 class Recipe(recipe.Recipe):
     name = 'gtk-sharp'
-    version = '2.12.42'
+    version = '2.12.45'
     licenses = [License.LGPL]
     stype = SourceType.TARBALL
     deps = ['gtk+', 'libglade', 'mono']
-    url = 'https://github.com/mono/gtk-sharp/archive/2.12.42.tar.gz'
+    url = 'https://github.com/mono/gtk-sharp/archive/%(version)s.tar.gz'
     config_sh = 'sh bootstrap-2.12'
 
     files_gapi = [


### PR DESCRIPTION
This fixes the pixbuf memory leaks (commit https://github.com/mono/gtk-sharp/commit/f610d89c3e510ba75349b876cb83a5a26a472d0e)