### PR TITLE
Debian: Add intltool to apt-get list.

### DIFF
--- a/cerbero/bootstrap/linux.py
+++ b/cerbero/bootstrap/linux.py
@@ -48,7 +48,8 @@ class DebianBootstraper (UnixBootstraper):
                 'libxdamage-dev', 'libxcomposite-dev', 'libasound2-dev',
                 'libxml-simple-perl', 'dpkg-dev', 'debhelper',
                 'build-essential', 'devscripts', 'fakeroot', 'transfig',
-                'gperf', 'libdbus-glib-1-dev', 'wget', 'glib-networking', 'git']
+                'gperf', 'libdbus-glib-1-dev', 'wget', 'glib-networking',
+                'intltool', 'git']
     distro_packages = {
         DistroVersion.DEBIAN_SQUEEZE: ['libgtk2.0-dev'],
         DistroVersion.UBUNTU_MAVERICK: ['libgtk2.0-dev'],


### PR DESCRIPTION
Continues INF-165: build support for Debian 9 (Stretch).