### PR TITLE
Updating default version of gettext-m4, to make

### DIFF
--- a/recipes/build-tools/gettext-m4.recipe
+++ b/recipes/build-tools/gettext-m4.recipe
@@ -3,7 +3,7 @@ import shutil
 
 class Recipe(recipe.Recipe):
     name = 'gettext-m4'
-    version = '0.18.3.2'
+    version = '0.19.5.1'
     stype = SourceType.TARBALL
     tarball_dirname = 'gettext-%(version)s'
     url = 'http://ftp.gnu.org/pub/gnu/gettext/gettext-%(version)s.tar.gz'


### PR DESCRIPTION
m4 doesn't fail on OSX 10.13 High Sierra.
(INF-163)