### PR TITLE
recipes/build-tools/m4: add patch for m4 from macports, so it works

### DIFF
--- a/recipes/build-tools/gettext-m4.recipe
+++ b/recipes/build-tools/gettext-m4.recipe
@@ -11,7 +11,9 @@ class Recipe(recipe.Recipe):
     licenses = [License.LGPLv2Plus]
     autoreconf = True
     btype = BuildType.CUSTOM
-
+    # same patch as for gettext-tools
+    patches = ['gettext-tools/secure_snprintf.patch']
+    
     files_devel = [
             'share/aclocal/codeset.m4',
             'share/aclocal/fcntl-o.m4',

--- a/recipes/build-tools/gettext-tools.recipe
+++ b/recipes/build-tools/gettext-tools.recipe
@@ -15,6 +15,7 @@ class Recipe(recipe.Recipe):
     configure_options = ' --disable-java --disable-csharp --disable-native-java --without-csv'
     files_libs = ['libintl']
     files_devel = ['include/libintl.h']
+    patches = ['gettext-tools/secure_snprintf.patch']
 
     def prepare(self):
         if self.config.target_platform == Platform.WINDOWS:

--- a/recipes/build-tools/gettext-tools/secure_snprintf.patch
+++ b/recipes/build-tools/gettext-tools/secure_snprintf.patch
@@ -1,0 +1,51 @@
+With format string strictness, High Sierra also enforces that %n isn't used
+in dynamic format strings, but we should just disable its use on darwin in
+general.
+
+--- a/gettext-runtime/intl/vasnprintf.c	2017-06-22 15:19:15.000000000 -0700
++++ b/gettext-runtime/intl/vasnprintf.c	2017-06-22 15:20:20.000000000 -0700
+@@ -4869,7 +4869,7 @@ VASNPRINTF (DCHAR_T *resultbuf, size_t *
+ #endif
+                   *fbp = dp->conversion;
+ #if USE_SNPRINTF
+-# if !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
++# if !defined(__APPLE__) && !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
+                 fbp[1] = '%';
+                 fbp[2] = 'n';
+                 fbp[3] = '\0';
+
+--- a/gettext-runtime/libasprintf/vasnprintf.c	2017-06-22 15:19:15.000000000 -0700
++++ b/gettext-runtime/libasprintf/vasnprintf.c	2017-06-22 15:20:20.000000000 -0700
+@@ -4869,7 +4869,7 @@ VASNPRINTF (DCHAR_T *resultbuf, size_t *
+ #endif
+                   *fbp = dp->conversion;
+ #if USE_SNPRINTF
+-# if !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
++# if !defined(__APPLE__) && !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
+                 fbp[1] = '%';
+                 fbp[2] = 'n';
+                 fbp[3] = '\0';
+
+--- a/gettext-tools/libgettextpo/vasnprintf.c	2017-06-22 15:19:15.000000000 -0700
++++ b/gettext-tools/libgettextpo/vasnprintf.c	2017-06-22 15:20:20.000000000 -0700
+@@ -4869,7 +4869,7 @@ VASNPRINTF (DCHAR_T *resultbuf, size_t *
+ #endif
+                   *fbp = dp->conversion;
+ #if USE_SNPRINTF
+-# if !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
++# if !defined(__APPLE__) && !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
+                 fbp[1] = '%';
+                 fbp[2] = 'n';
+                 fbp[3] = '\0';
+
+--- a/gettext-tools/gnulib-lib/vasnprintf.c	2017-06-22 15:19:15.000000000 -0700
++++ b/gettext-tools/gnulib-lib/vasnprintf.c	2017-06-22 15:20:20.000000000 -0700
+@@ -4869,7 +4869,7 @@ VASNPRINTF (DCHAR_T *resultbuf, size_t *
+ #endif
+                   *fbp = dp->conversion;
+ #if USE_SNPRINTF
+-# if !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
++# if !defined(__APPLE__) && !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
+                 fbp[1] = '%';
+                 fbp[2] = 'n';
+                 fbp[3] = '\0';

--- a/recipes/build-tools/m4.recipe
+++ b/recipes/build-tools/m4.recipe
@@ -8,6 +8,7 @@ class Recipe(recipe.Recipe):
     stype = SourceType.TARBALL
     url = 'http://ftp.gnu.org/gnu/m4/m4-1.4.17.tar.gz'
     files_bins = ['m4']
+    patches = ['m4/secure_snprintf.patch']
 
     def prepare(self):
         self.append_env['CFLAGS'] = " -Wno-error=cast-align "

--- a/recipes/build-tools/m4/secure_snprintf.patch
+++ b/recipes/build-tools/m4/secure_snprintf.patch
@@ -1,0 +1,15 @@
+With format string strictness, High Sierra also enforces that %n isn't used
+in dynamic format strings, but we should just disable its use on darwin in
+general.
+
+--- a/lib/vasnprintf.c	2017-06-22 15:19:15.000000000 -0700
++++ b/lib/vasnprintf.c	2017-06-22 15:20:20.000000000 -0700
+@@ -4869,7 +4869,7 @@ VASNPRINTF (DCHAR_T *resultbuf, size_t *
+ #endif
+                   *fbp = dp->conversion;
+ #if USE_SNPRINTF
+-# if !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
++# if !defined(__APPLE__) && !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
+                 fbp[1] = '%';
+                 fbp[2] = 'n';
+                 fbp[3] = '\0';

--- a/recipes/glib.recipe
+++ b/recipes/glib.recipe
@@ -35,7 +35,8 @@ class Recipe(recipe.Recipe):
                "glib/0006-giomodule-do-not-try-to-load-modules-from-gio-module.patch",
                "glib/0008-gdbus-codgen-Use-a-proper-shebang-in-the-generator.patch",
                "glib/0009-Unhide-_g_io_modules_ensure_extension_points_registe.patch",
-               'glib/0015-Implementation-of-Cocoa-event-loop-integration-in-GM.patch'
+               'glib/0015-Implementation-of-Cocoa-event-loop-integration-in-GM.patch',
+               'glib/secure_snprintf.patch'
               ]
 
     files_libs = [

--- a/recipes/glib/secure_snprintf.patch
+++ b/recipes/glib/secure_snprintf.patch
@@ -1,0 +1,15 @@
+With format string strictness, High Sierra also enforces that %n isn't used
+in dynamic format strings, but we should just disable its use on darwin in
+general.
+
+--- a/glib/gnulib/vasnprintf.c	2017-06-22 15:19:15.000000000 -0700
++++ b/glib/gnulib/vasnprintf.c	2017-06-22 15:20:20.000000000 -0700
+@@ -4843,7 +4843,7 @@ VASNPRINTF (DCHAR_T *resultbuf, size_t *
+ #endif
+                   *fbp = dp->conversion;
+ #if USE_SNPRINTF
+-# if !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
++# if !defined(__APPLE__) && !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
+                 fbp[1] = '%';
+                 fbp[2] = 'n';
+                 fbp[3] = '\0';

--- a/recipes/gnutls.recipe
+++ b/recipes/gnutls.recipe
@@ -22,7 +22,9 @@ class Recipe(recipe.Recipe):
         Platform.IOS: ['bionic-fixup'],
         Platform.DARWIN: ['bionic-fixup']
     }
-    patches = [name + "/0001-configure-vasprintf-is-defined-in-stdio.h.patch"]
+    patches = [
+        name + "/0001-configure-vasprintf-is-defined-in-stdio.h.patch",
+        name + "/secure_snprintf.patch"]
     autoreconf = True
 
     files_libs = ['libgnutls', 'libgnutlsxx']

--- a/recipes/gnutls/secure_snprintf.patch
+++ b/recipes/gnutls/secure_snprintf.patch
@@ -1,0 +1,27 @@
+With format string strictness, High Sierra also enforces that %n isn't used
+in dynamic format strings, but we should just disable its use on darwin in
+general.
+
+--- a/gl/vasnprintf.c	2017-06-22 15:19:15.000000000 -0700
++++ b/gl/vasnprintf.c	2017-06-22 15:20:20.000000000 -0700
+@@ -4857,7 +4857,7 @@ VASNPRINTF (DCHAR_T *resultbuf, size_t *
+ #endif
+                   *fbp = dp->conversion;
+ #if USE_SNPRINTF
+-# if !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
++# if !defined(__APPLE__) && !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
+                 fbp[1] = '%';
+                 fbp[2] = 'n';
+                 fbp[3] = '\0';
+
+--- a/src/gl/vasnprintf.c	2017-06-22 15:19:15.000000000 -0700
++++ b/src/gl/vasnprintf.c	2017-06-22 15:20:20.000000000 -0700
+@@ -4857,7 +4857,7 @@ VASNPRINTF (DCHAR_T *resultbuf, size_t *
+ #endif
+                   *fbp = dp->conversion;
+ #if USE_SNPRINTF
+-# if !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
++# if !defined(__APPLE__) && !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
+                 fbp[1] = '%';
+                 fbp[2] = 'n';
+                 fbp[3] = '\0';


### PR DESCRIPTION
correctly on OSX 10.13 High Sierra

same patch (with difference in start line and paths sometimes)
 also applies for:
- glib
- gnutls
- build-tools/gettext-tools
- build-tools/gettext-m4