### PR TITLE
Add gtk-doc to the build tools if the docs variant exists

### DIFF
--- a/cerbero/bootstrap/build_tools.py
+++ b/cerbero/bootstrap/build_tools.py
@@ -66,6 +66,8 @@ class BuildTools (BootstraperBase):
                 not self.config.prefix_is_executable():
             # For glib-mkenums and glib-genmarshal
             self.BUILD_TOOLS.append('glib-tools')
+        if self.config.variants.doc:
+            self.BUILD_TOOLS.append('gtk-doc')
         self.BUILD_TOOLS += self.config.extra_build_tools
 
     def start(self):

--- a/cerbero/build/recipe.py
+++ b/cerbero/build/recipe.py
@@ -203,8 +203,6 @@ class Recipe(FilesProvider):
         deps.extend(self.deps)
         if self.config.target_platform in self.platform_deps:
             deps.extend(self.platform_deps[self.config.target_platform])
-        if self.config.variants.doc and self.use_gtkdoc:
-            deps.append('gtk-doc')
         return deps
 
     def list_licenses_by_categories(self, categories):


### PR DESCRIPTION
This PR adds gtk-doc dependency to the build tools instead of the recipe