### PR TITLE
Fix url for fribidi package

### DIFF
--- a/recipes/fribidi.recipe
+++ b/recipes/fribidi.recipe
@@ -4,7 +4,7 @@ class Recipe(recipe.Recipe):
     name = 'fribidi'
     version = '0.19.6'
     stype = SourceType.TARBALL
-    url = 'http://fribidi.org/download/fribidi-%(version)s.tar.bz2'
+    url = 'https://download.videolan.org/contrib/fribidi/fribidi-%(version)s.tar.bz2'
     licenses = [License.LGPLv2_1Plus]
     autoreconf = True
     deps = ['glib']


### PR DESCRIPTION
fribidi.org/download is not valid anymore.
Use VLC repository instead