### PR TITLE
For crosscompiling to x86 and x86_64 let user just specify the "-m" f…

### DIFF
--- a/config/linux.config
+++ b/config/linux.config
@@ -48,13 +48,20 @@ if target_arch in [Architecture.ARM, Architecture.ARMv7]:
 if target_arch_flags is not None:
     arch_flags += ' %s ' % (target_arch_flags)
 
-if host is None and target_arch != arch:
-    host = _host
+host_was_specified_before = 'true'
+if host is None:
+    if target_arch != arch:
+         host = _host
+    host_was_specified_before = 'false'
 
 tools_prefix = ''
 if host is not None:
     tools_prefix = '%s-' % host
-
+    # for case of simple cross-compiling between x86 and x86_64
+    # don't force overriding the toolchain prefix
+    if host_was_specified_before == 'false' and \
+    target_arch != Architecture.X86 and target_arch != Architecture.X86_64:
+        tools_prefix=''
 
 # Some cross compilers have a bug in the search for indirect dependencies
 # during linking. 


### PR DESCRIPTION
…lag.

Reason: to skip installing toolchain for easy cases.
Automake should handle it and give priority to cross-toolchain first,
we just don't force overriding the compiler.