### PR TITLE
Copy the static version of libstdc++

### DIFF
--- a/recipes/mingw-runtime.recipe
+++ b/recipes/mingw-runtime.recipe
@@ -64,10 +64,14 @@ class Recipe(recipe.Recipe):
                 os.path.join(self.config.prefix, 'bin', f + '.dll'))
         # copy the development libraries
         for f in ['libstdc++', 'libgomp']:
-            # Copy the dll.a
+            # Copy the dll.a and .a
             shutil.copy(
                 os.path.join(self.config.toolchain_prefix, libmingw, f + '.dll.a'),
                 os.path.join(self.config.prefix, 'lib', f + '.dll.a'))
+            # Copy the .a
+            shutil.copy(
+                os.path.join(self.config.toolchain_prefix, libmingw, f + '.a'),
+                os.path.join(self.config.prefix, 'lib', f + '.a'))
             # Copy and update the .la
             src = os.path.join(self.config.toolchain_prefix, libmingw, f + '.la')
             dest = os.path.join(self.config.prefix, 'lib', f + '.la')


### PR DESCRIPTION
The static version of libstdc++ is necessary to get
rid of dynamic dependencies.