### PR TITLE
WIX fragment should take 'is_app' into account

### DIFF
--- a/cerbero/packages/wix.py
+++ b/cerbero/packages/wix.py
@@ -177,8 +177,12 @@ class Fragment(WixBase):
             Id=self._format_group_id(self.package.name))
 
     def _add_root_dir(self):
-        self.rdir = etree.SubElement(self.fragment, "DirectoryRef",
-            Id='INSTALLDIR')
+        if self._is_app():
+          self.rdir = etree.SubElement(self.fragment, "DirectoryRef",
+              Id='INSTALLDIR')
+        else:
+          self.rdir = etree.SubElement(self.fragment, "DirectoryRef",
+              Id='SDKROOTDIR')
         self._dirnodes[''] = self.rdir
 
     def _add_files(self):


### PR DESCRIPTION
The install dir is different in the case of an app
installer or not. The Fragment class containing the files
should use SDKROOTDIR instead of INSTALLDIR in the case
of non app.
See: _add_install_dir in MSI class