### PR TITLE
LMA-321 - Set the version correctly in the couchbase build process

### DIFF
--- a/recipes/couchbase-lite/couchbase-lite.recipe
+++ b/recipes/couchbase-lite/couchbase-lite.recipe
@@ -46,6 +46,8 @@ class Recipe(recipe.Recipe):
             self.append_env = {}
             self.new_env =  {'MONO_PATH' : None}
             self.new_env["PATH"] = "/Library/Frameworks/Mono.framework/Commands/:" + os.environ["PATH"]
+        self.short_version = '.'.join(self.version.split('.')[:-1])
+        self.major_version = '.'.join(self.short_version.split('.')[:-1])
 
     def extract(self):
         super(recipe.Recipe, self).extract()
@@ -53,9 +55,15 @@ class Recipe(recipe.Recipe):
 
     @modify_environment
     def compile(self):
+        os.environ["VERSION"] = self.version
+        os.environ["NUGET_VERSION"] = self.short_version
         logging.info('Compiling Couchbase')
         shell.call("nuget restore " \
                    "src/Couchbase.Lite.Net45.sln -source 'https://www.nuget.org/api/v2/'", self.build_dir)
+        shell.call("mono src/packages/Mono.TextTemplating.1.3.1/tools/TextTransform.exe"
+                   " -o src/Couchbase.Lite.Shared/Properties/DynamicAssemblyInfo.cs"
+                   " src/Couchbase.Lite.Shared/Properties/DynamicAssemblyInfo.tt",
+                   self.build_dir)
         shell.call('xbuild src/Couchbase.Lite.Net45/Couchbase.Lite.Net45.csproj '
                    ' /property:SolutionDir=' + self.build_dir + '/src/'
                    ' /property:Configuration=Release /property:Archive=true', self.build_dir)


### PR DESCRIPTION
It checks the VERSION env var to generate the AssemblyInfo used for versioning, and we generate it using TextTransform (we added the NuGet in our couchbase fork)