### PR TITLE
Fix when download_curl replace download

### DIFF
--- a/cerbero/bootstrap/build_tools.py
+++ b/cerbero/bootstrap/build_tools.py
@@ -91,7 +91,7 @@ class BuildTools (BootstraperBase):
         config.binary_repo = self.config.binary_repo + '/build-tools'
         config.binary_repo_username = self.config.binary_repo_username
         config.binary_repo_password = self.config.binary_repo_password
-        config.mirror_url = self.config.mirror_url
+        config.cache_url = self.config.cache_url
 
         if not os.path.exists(config.prefix):
             os.makedirs(config.prefix)

--- a/cerbero/bootstrap/linux.py
+++ b/cerbero/bootstrap/linux.py
@@ -49,7 +49,7 @@ class UnixBootstraper (BootstraperBase):
         for package_name in package_names:
           package_dest_filename = os.path.expanduser('%s/%s' % (package_path, package_name))
           url = '%s/%s/%s' % (CUSTOM_WINE_PACKAGE_PATH, path_name, package_name)
-          shell.download(url, package_dest_filename, mirror_url=self.config.mirror_url)
+          shell.download(url, package_dest_filename, cache_url=self.config.cache_url)
 
     def _download_missing_wine_deps(self):
         self._download_wine_package('dotnet40', ["gacutil-net40.tar.bz2"])

--- a/cerbero/bootstrap/osx.py
+++ b/cerbero/bootstrap/osx.py
@@ -42,7 +42,7 @@ class OSXBootstraper (BootstraperBase):
         return
         tar = self.GCC_TAR[self.config.distro_version]
         url = os.path.join(self.GCC_BASE_URL, tar)
-        pkg = os.path.join(self.config.local_sources, tar, mirror_url=self.config.mirror_url)
+        pkg = os.path.join(self.config.local_sources, tar, cache_url=self.config.cache_url)
         shell.download(url, pkg, check_cert=False)
         shell.call('sudo installer -pkg %s -target /' % pkg)
 
@@ -50,7 +50,7 @@ class OSXBootstraper (BootstraperBase):
         # Install cpan-minus, a zero-conf CPAN wrapper
         tmp = tempfile.NamedTemporaryFile()
         cpanm_installer = tmp.name
-        shell.download(self.CPANM_URL, cpanm_installer, mirror_url=self.config.mirror_url)
+        shell.download(self.CPANM_URL, cpanm_installer, cache_url=self.config.cache_url)
         shell.call('chmod +x %s' % cpanm_installer)
         # Install XML::Parser, required for intltool
         shell.call("sudo %s XML::Parser" % cpanm_installer)

--- a/cerbero/bootstrap/windows.py
+++ b/cerbero/bootstrap/windows.py
@@ -85,7 +85,7 @@ class WindowsBootstraper(BootstraperBase):
 
         tarfile = os.path.join(self.prefix, tarball)
         tarfile = os.path.abspath(tarfile)
-        shell.download("%s/%s" % (MINGW_DOWNLOAD_SOURCE, tarball), tarfile, False, False, mirror_url=self.config.mirror_url)
+        shell.download("%s/%s" % (MINGW_DOWNLOAD_SOURCE, tarball), tarfile, False, False, cache_url=self.config.cache_url)
         if not os.path.exists(os.path.join(self.prefix, 'bin')):
             try:
                 shell.unpack(tarfile, self.prefix)

--- a/cerbero/build/source.py
+++ b/cerbero/build/source.py
@@ -133,7 +133,7 @@ class Tarball (Source):
         if self.url.startswith('file://'):
             shutil.copy(self.url[7:], self.download_path)
         else:
-            shell.download(self.url, self.download_path, check_cert=False, mirror_url=self.config.mirror_url, filename=self.tarball_name)
+            shell.download(self.url, self.download_path, check_cert=False, cache_url=self.config.cache_url, filename=self.tarball_name)
 
     def extract(self):
         m.action(_('Extracting tarball to %s') % self.build_dir)

--- a/cerbero/config.py
+++ b/cerbero/config.py
@@ -102,7 +102,7 @@ class Config (object):
                    'build_tools_prefix', 'build_tools_sources',
                    'build_tools_cache', 'home_dir', 'recipes_commits',
                    'ios_platform', 'extra_build_tools', 'target_arch_flags',
-                   'extra_bootstrap_packages', 'binary_commits', 'mirror_url',
+                   'extra_bootstrap_packages', 'binary_commits', 'cache_url',
                    'ignore_runtime_deps', 'binaries', 'binary_repo',
                    'binary_repo_username', 'binary_repo_password', 'custom_cflags']
 
@@ -328,7 +328,7 @@ class Config (object):
         self.set_property('build_tools_cache', None)
         self.set_property('recipes_commits', {})
         self.set_property('binary_commits', {})
-        self.set_property('mirror_url', None)
+        self.set_property('cache_url', None)
         self.set_property('extra_build_tools', {})
         self.set_property('extra_bootstrap_packages', {})
         self.set_property('ignore_runtime_deps', False)

--- a/cerbero/utils/shell.py
+++ b/cerbero/utils/shell.py
@@ -160,28 +160,28 @@ def unpack(filepath, output_dir):
         zf.extractall(path=output_dir)
 
 
-def _get_download_mirror_url(url, mirror_url, filename = None):
+def _get_download_cache_url(url, cache_url, filename = None):
     '''
-    Get the mirror url if available
+    Get the cache url if available
 
     @param url: original url to download
     @type url: str
-    @param mirror_url: base mirror url to use
-    @type mirror_url: str
+    @param cache_url: base cache url to use
+    @type cache_url: str
     @param filename: custom filename to use
     @type filename: str
     '''
-    if mirror_url is None:
+    if cache_url is None:
       return url
     if filename is None:
-      dl_mirror_url = mirror_url + os.path.basename(url)
+      dl_cache_url = cache_url + os.path.basename(url)
     else:
-      dl_mirror_url = mirror_url + filename
-    logging.info('Using the mirror url: %s instead of %s' % (dl_mirror_url, url))
-    return dl_mirror_url
+      dl_cache_url = cache_url + filename
+    logging.info('Using the cache url: %s instead of %s' % (dl_cache_url, url))
+    return dl_cache_url
 
 
-def download(url, destination=None, recursive=False, check_cert=True, user=None, password=None, mirror_url=None, filename = None):
+def download(url, destination=None, recursive=False, check_cert=True, user=None, password=None, cache_url=None, filename = None):
     '''
     Downloads a file with wget
 
@@ -193,16 +193,16 @@ def download(url, destination=None, recursive=False, check_cert=True, user=None,
     @type user: str
     @param password: the password to use when connecting
     @type password: str
-    @param mirror_url: mirror url to try first
-    @type mirror_url: str
-    @param filename: custom filename to use by the mirror url
+    @param cache_url: cache url to try first
+    @type cache_url: str
+    @param filename: custom filename to use by the cache url
     @type filename: str
     '''
     original_url = None
-    mirror_url = _get_download_mirror_url(url, mirror_url, filename)
-    if mirror_url != url:
+    cache_url = _get_download_cache_url(url, cache_url, filename)
+    if cache_url != url:
       original_url = url
-      url = mirror_url
+      url = cache_url
     cmd = "wget %s " % url
     path = None
     if recursive:
@@ -230,7 +230,7 @@ def download(url, destination=None, recursive=False, check_cert=True, user=None,
             os.remove(destination)
             if original_url is not None:
               try:
-                cmd = cmd.replace(mirror_url, original_url)
+                cmd = cmd.replace(cache_url, original_url)
                 call(cmd, path)
               except FatalError, e:
                 os.remove(destination)
@@ -239,7 +239,7 @@ def download(url, destination=None, recursive=False, check_cert=True, user=None,
               raise e
 
 
-def download_curl(url, destination=None, recursive=False, check_cert=True, user=None, password=None, overwrite=False, mirror_url=None, filename = None):
+def download_curl(url, destination=None, recursive=False, check_cert=True, user=None, password=None, overwrite=False, cache_url=None, filename = None):
     '''
     Downloads a file with cURL
 
@@ -253,9 +253,9 @@ def download_curl(url, destination=None, recursive=False, check_cert=True, user=
     @type password: str
     @param overwrite: in case the file exists overwrite it
     @type overwrite: bool
-    @param mirror_url: mirror url to try first
-    @type mirror_url: str
-    @param filename: custom filename to use by the mirror url
+    @param cache_url: cache url to try first
+    @type cache_url: str
+    @param filename: custom filename to use by the cache url
     @type filename: str
     '''
     path = None
@@ -263,10 +263,10 @@ def download_curl(url, destination=None, recursive=False, check_cert=True, user=
         raise FatalError(_("cURL doesn't support recursive downloads"))
 
     original_url = None
-    mirror_url = _get_download_mirror_url(url, mirror_url, filename)
-    if mirror_url != url:
+    cache_url = _get_download_cache_url(url, cache_url, filename)
+    if cache_url != url:
       original_url = url
-      url = mirror_url
+      url = cache_url
 
     cmd = "curl -L "
     if user:
@@ -292,7 +292,7 @@ def download_curl(url, destination=None, recursive=False, check_cert=True, user=
             os.remove(destination)
             if original_url is not None:
               try:
-                cmd = cmd.replace(mirror_url, original_url)
+                cmd = cmd.replace(cache_url, original_url)
                 call(cmd, path)
               except FatalError, e:
                 os.remove(destination)


### PR DESCRIPTION
After mirror url implementation, download_curl
needs also to support the mirroring system.