### PR TITLE
Fix the openssl devel files permissions

### DIFF
--- a/recipes/openssl.recipe
+++ b/recipes/openssl.recipe
@@ -111,12 +111,12 @@ class Recipe(recipe.Recipe):
 
     def post_install(self):
         # Fix permissions for installed libs
-        libs_to_fix = self.libraries()
+        files_to_fix = self.libraries()
         # In case of windows we have one more file
         if self.config.target_platform == Platform.WINDOWS:
-            libs_to_fix.append('lib/libcrypto.dll.a')
-        for lib in libs_to_fix:
-            shell.call("chmod 666 %s" % os.path.join(self.config.prefix, lib))
+            files_to_fix += self.files_devel
+        for f in files_to_fix:
+            shell.call("chmod u+rw %s" % os.path.join(self.config.prefix, f))
 
         # XXX: Don't forget to update this when the soname is bumped!
         # We don't build shared libraries on iOS as the build system


### PR DESCRIPTION
Fix libssl.dll.a 555 permission preventing the reinstall
of the binaries with extract_binary.