### PR TITLE
extra_build_tools should be initialized to array

### DIFF
--- a/cerbero/config.py
+++ b/cerbero/config.py
@@ -329,7 +329,7 @@ class Config (object):
         self.set_property('recipes_commits', {})
         self.set_property('binary_commits', {})
         self.set_property('cache_url', None)
-        self.set_property('extra_build_tools', {})
+        self.set_property('extra_build_tools', [])
         self.set_property('extra_bootstrap_packages', {})
         self.set_property('ignore_runtime_deps', False)
         self.set_property('binaries', None)


### PR DESCRIPTION
In order to be used corfrectly by BUILD_TOOLS in build_tools.py
The variable should be initialized as an array.