### PR TITLE
Also check for winpthread library

### DIFF
--- a/recipes/gstreamer.recipe
+++ b/recipes/gstreamer.recipe
@@ -65,6 +65,7 @@ class Recipe(recipe.Recipe):
         if self.config.variants.nodebug:
             self.configure_options += ' --disable-gst-debug'
 
+	
     def extract(self):
         self.stype.extract(self)
         git.checkout(self.build_dir, 'HEAD')
@@ -76,4 +77,7 @@ class Recipe(recipe.Recipe):
                                                DistroVersion.DEBIAN_STRETCH]):
             _patch = self.relative_path('gstreamer/0001-gst-parse-switch-to-lex-param.patch')
             shell.apply_patch(_patch, self.build_dir, 1)
+            _patch = self.relative_path('gstreamer/0002-also-check-for-winpthread.patch')
+            shell.apply_patch(_patch, self.build_dir, 1)
+
 

--- a/recipes/gstreamer/0002-also-check-for-winpthread.patch
+++ b/recipes/gstreamer/0002-also-check-for-winpthread.patch
@@ -1,0 +1,16 @@
+diff --git a/configure.ac b/configure.ac
+index 238b19e..12bfd64 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -453,6 +453,11 @@ AC_CHECK_FUNCS(clock_gettime, [], [
+   AC_CHECK_LIB(rt, clock_gettime, [
+     AC_DEFINE(HAVE_CLOCK_GETTIME, 1)
+     LIBS="$LIBS -lrt"
++  ], [
++    AC_CHECK_LIB(winpthread, clock_gettime, [
++      AC_DEFINE(HAVE_CLOCK_GETTIME, 1)
++      LIBS="$LIBS -lwinpthread"
++    ])
+   ])
+ ])
+ 


### PR DESCRIPTION
In new versions of mingw clock_gettime and other time functions
are not longer part of the standard library, they have been
moved to wipthread library instead
This patch applies a patch into gstreamer's configure.ac in
order to check if clock_gettime is being provided by winpthread