### PR TITLE
Disable deprecated extended call

### DIFF
--- a/recipes/libffi.recipe
+++ b/recipes/libffi.recipe
@@ -25,7 +25,9 @@ class Recipe(recipe.Recipe):
     remotes = {'origin': 'https://github.com/atgreen/libffi.git'}
     commit = '60e4250a77eb3fde500bfd68ec40519fe34b21bd'
     licenses = [License.BSD_like]
-    patches = ['libffi/0001-enable-pic-unix64-abort-call.patch']
+    patches = ['libffi/0001-enable-pic-unix64-abort-call.patch',
+              'libffi/0002-disable-unsupported-deprecated-call.patch'
+              ]
 
     files_libs = ['libffi']
     files_devel = ['lib/libffi-3.99999/include/ffi.h', 'lib/pkgconfig/libffi.pc']

--- a/recipes/libffi/0002-disable-unsupported-deprecated-call.patch
+++ b/recipes/libffi/0002-disable-unsupported-deprecated-call.patch
@@ -1,0 +1,13 @@
+diff --git a/include/ffi.h.in b/include/ffi.h.in
+index 5833525..8a50615 100644
+--- a/include/ffi.h.in
++++ b/include/ffi.h.in
+@@ -315,7 +315,7 @@ ffi_prep_closure (ffi_closure*,
+ 		  ffi_cif *,
+ 		  void (*fun)(ffi_cif*,void*,void**,void*),
+ 		  void *user_data)
+-  __attribute__((deprecated ("use ffi_prep_closure_loc instead")));
++  __attribute__((deprecated));
+ 
+ ffi_status
+ ffi_prep_closure_loc (ffi_closure*,


### PR DESCRIPTION
Disable the call to 'deprecated' with parameter
unsupported by old gcc versions