### PR TITLE
Several changes for Mingw >5.3 compatibility

### DIFF
--- a/recipes/gst-plugins-base.recipe
+++ b/recipes/gst-plugins-base.recipe
@@ -150,6 +150,7 @@ class Recipe(recipe.Recipe):
         if self.config.target_distro_version == DistroVersion.UBUNTU_HARDY and \
                 self.config.target_arch == Architecture.X86:
             self.new_env['CFLAGS'] = os.environ['CFLAGS'] + ' -msse2'
+        self.patches+=['gst-plugins-base/0002-Explicitly-added-SSE-support.patch']
 
         if self.config.target_platform == Platform.IOS:
           self.patches += ['gst-plugins-base/0001-disable-orc-test-IOS.patch']

--- a/recipes/gst-plugins-base/0002-Explicitly-added-SSE-support.patch
+++ b/recipes/gst-plugins-base/0002-Explicitly-added-SSE-support.patch
@@ -1,0 +1,61 @@
+From 2c82208c37d2e1c2a2b795e3db0a3c9a145695ca Mon Sep 17 00:00:00 2001
+From: Nacho Garcia <ngarcia@fluendo.com>
+Date: Mon, 1 Oct 2018 15:48:44 +0200
+Subject: [PATCH] Explicitly added SSE support
+
+Returning SSE vectors without explicitly enabling
+SSE support causes an error on new mingw versions
+This patch explicitly enables SSE if available,
+setting flags up to SSE4.1 version
+---
+ configure.ac                  | 17 +++++++++++++++++
+ gst/audioresample/Makefile.am |  5 ++++-
+ 2 files changed, 21 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 2d24f3e..3b4ad26 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -189,6 +189,23 @@ AC_COMPILE_IFELSE(
+ CPPFLAGS="$ac_cppflags_save"
+ AM_CONDITIONAL(HAVE_LIBXML_HTML, test "x$HAVE_LIBXML_HTML" = "xyes")
+ 
++dnl check for -m* compiler flags too
++SSE_CFLAGS="-msse"
++SSE2_CFLAGS="-msse2"
++SSE41_CFLAGS="-msse4.1"
++
++AS_COMPILER_FLAG([$SSE_CFLAGS], [HAVE_SSE=1], [HAVE_SSE=0])
++AS_COMPILER_FLAG([$SSE2_CFLAGS], [HAVE_SSE2=1], [HAVE_SSE2=0])
++AS_COMPILER_FLAG([$SSE41_CFLAGS], [HAVE_SSE41=1], [HAVE_SSE41=0])
++
++AC_DEFINE_UNQUOTED(HAVE_SSE, [$HAVE_SSE], [SSE support is enabled])
++AC_DEFINE_UNQUOTED(HAVE_SSE2, [$HAVE_SSE2], [SSE2 support is enabled])
++AC_DEFINE_UNQUOTED(HAVE_SSE41, [$HAVE_SSE41], [SSE4.1 support is enabled])
++
++AC_SUBST(SSE_CFLAGS)
++AC_SUBST(SSE2_CFLAGS)
++AC_SUBST(SSE41_CFLAGS)
++
+ dnl used in gst/tcp
+ AC_CHECK_HEADERS([sys/socket.h],
+   HAVE_SYS_SOCKET_H="yes", HAVE_SYS_SOCKET_H="no")
+diff --git a/gst/audioresample/Makefile.am b/gst/audioresample/Makefile.am
+index dc02daf..9150972 100644
+--- a/gst/audioresample/Makefile.am
++++ b/gst/audioresample/Makefile.am
+@@ -17,7 +17,10 @@ libgstaudioresample_la_CFLAGS = \
+ 	$(GST_PLUGINS_BASE_CFLAGS) \
+ 	$(GST_BASE_CFLAGS) \
+ 	$(GST_CFLAGS) \
+-	$(ORC_CFLAGS)
++	$(ORC_CFLAGS) \
++	$(SSE_CFLAGS) \
++	$(SSE2_CFLAGS) \
++	$(SSE41_CFLAGS)
+ 
+ libgstaudioresample_la_LIBADD = \
+ 	$(GST_BASE_LIBS) \
+-- 
+2.7.4
+

--- a/recipes/gstreamer.recipe
+++ b/recipes/gstreamer.recipe
@@ -65,15 +65,19 @@ class Recipe(recipe.Recipe):
         if self.config.variants.nodebug:
             self.configure_options += ' --disable-gst-debug'
 
-    def extract(self):
-        self.stype.extract(self)
-        git.checkout(self.build_dir, 'HEAD')
+        self.patches=['gstreamer/0002-also-check-for-winpthread.patch']
+
         if self.config.target_platform == Platform.DARWIN or \
                 (self.config.platform == Platform.LINUX and \
                 self.config.distro_version in [DistroVersion.UBUNTU_TRUSTY, DistroVersion.UBUNTU_UTOPIC, \
                                                DistroVersion.UBUNTU_VIVID, DistroVersion.UBUNTU_WILY, \
                                                DistroVersion.UBUNTU_XENIAL, DistroVersion.UBUNTU_BIONIC, \
                                                DistroVersion.DEBIAN_STRETCH]):
-            _patch = self.relative_path('gstreamer/0001-gst-parse-switch-to-lex-param.patch')
-            shell.apply_patch(_patch, self.build_dir, 1)
+            self.patches+=['gstreamer/0001-gst-parse-switch-to-lex-param.patch']
+
+    def extract(self):
+        self.stype.extract(self)
+        git.checkout(self.build_dir, 'HEAD')
+        self.apply_patches()
+
 

--- a/recipes/gstreamer/0002-also-check-for-winpthread.patch
+++ b/recipes/gstreamer/0002-also-check-for-winpthread.patch
@@ -1,0 +1,16 @@
+diff --git a/configure.ac b/configure.ac
+index 238b19e..12bfd64 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -453,6 +453,11 @@ AC_CHECK_FUNCS(clock_gettime, [], [
+   AC_CHECK_LIB(rt, clock_gettime, [
+     AC_DEFINE(HAVE_CLOCK_GETTIME, 1)
+     LIBS="$LIBS -lrt"
++  ], [
++    AC_CHECK_LIB(winpthread, clock_gettime, [
++      AC_DEFINE(HAVE_CLOCK_GETTIME, 1)
++      LIBS="$LIBS -lwinpthread"
++    ])
+   ])
+ ])
+ 

--- a/recipes/libtheora.recipe
+++ b/recipes/libtheora.recipe
@@ -14,7 +14,10 @@ class Recipe(recipe.Recipe):
                'libtheora/0003-Fix-linking-of-theora-encoder-library.patch',
                'libtheora/0004-Use-our-automake-version-and-not-an-older-one.patch',
                'libtheora/0005-Update-Makefile.in-too-to-avoid-needing-to-call-auto.patch',
-               'libtheora/0006-examples-Don-t-use-png_sizeof.patch']
+               'libtheora/0006-examples-Don-t-use-png_sizeof.patch',
+               'libtheora/0008-Do-not-redefine-for-mingw.patch',
+               'libtheora/0009-remove-cr-rl.patch'
+               ]
 
     files_libs = ['libtheora', 'libtheoradec', 'libtheoraenc']
     files_devel = ['include/theora', 'lib/pkgconfig/theora.pc',

--- a/recipes/libtheora/0008-Do-not-redefine-for-mingw.patch
+++ b/recipes/libtheora/0008-Do-not-redefine-for-mingw.patch
@@ -1,0 +1,20 @@
+diff --git a/../b/examples/encoder_example.c b/examples/encoder_example.c
+index 4b73b64..13955d2 100755
+--- a/../b/examples/encoder_example.c
++++ b/examples/encoder_example.c
+@@ -52,6 +52,7 @@
+ #include <fcntl.h>
+ #include <io.h>
+ 
++#ifndef __GNUC__
+ static double rint(double x)
+ {
+   if (x < 0.0)
+@@ -60,6 +61,7 @@ static double rint(double x)
+     return (double)(int)(x + 0.5);
+ }
+ #endif
++#endif
+ 
+ const char *optstring = "b:e:o:a:A:v:V:s:S:f:F:ck:d:z:\1\2\3\4";
+ struct option options [] = {

--- a/recipes/libtheora/0009-remove-cr-rl.patch
+++ b/recipes/libtheora/0009-remove-cr-rl.patch
@@ -1,0 +1,178 @@
+From f6f4129ea7ab29a7e28b58c56fe2201a49c2f32c Mon Sep 17 00:00:00 2001
+From: Nacho Garcia <ngarcia@fluendo.com>
+Date: Wed, 3 Oct 2018 18:51:49 +0200
+Subject: [PATCH] Remove CR/LF
+
+Change .def file to UNIX format because having CR/LF confuses
+libtool and it will end with a duplicated 'EXPORTS' label
+(because libtool can't find 'EXPORTS\r'
+This duplicated label also causes a syntax error in new
+mingw versions
+---
+ win32/xmingw32/libtheoradec-all.def | 116 ++++++++++++++++++------------------
+ win32/xmingw32/libtheoraenc-all.def |  34 +++++------
+ 2 files changed, 75 insertions(+), 75 deletions(-)
+
+diff --git a/win32/xmingw32/libtheoradec-all.def b/win32/xmingw32/libtheoradec-all.def
+index 566eeb3..c753562 100644
+--- a/win32/xmingw32/libtheoradec-all.def
++++ b/win32/xmingw32/libtheoradec-all.def
+@@ -1,58 +1,58 @@
+-EXPORTS
+-; Old alpha API
+-	theora_version_string @ 1
+-	theora_version_number @ 2
+-
+-	theora_decode_header @ 3
+-	theora_decode_init @ 4
+-	theora_decode_packetin @ 5
+-	theora_decode_YUVout @ 6
+-
+-	theora_control @ 7
+-
+-	theora_packet_isheader @ 8
+-	theora_packet_iskeyframe @ 9
+-
+-	theora_granule_shift @ 10
+-	theora_granule_frame @ 11
+-	theora_granule_time @ 12
+-
+-	theora_info_init @ 13
+-	theora_info_clear @ 14
+-
+-	theora_clear @ 15
+-
+-	theora_comment_init @ 16
+-	theora_comment_add @ 17
+-	theora_comment_add_tag @ 18
+-	theora_comment_query @ 19
+-	theora_comment_query_count @ 20
+-	theora_comment_clear @ 21
+-
+-; New theora-exp API
+-	th_version_string @ 22
+-	th_version_number @ 23
+-
+-	th_decode_headerin @ 24
+-	th_decode_alloc @ 25
+-	th_setup_free @ 26
+-	th_decode_ctl @ 27
+-	th_decode_packetin @ 28
+-	th_decode_ycbcr_out @ 29
+-	th_decode_free @ 30
+-
+-	th_packet_isheader @ 31
+-	th_packet_iskeyframe @ 32
+-
+-	th_granule_frame @ 33
+-	th_granule_time @ 34
+-
+-	th_info_init @ 35
+-	th_info_clear @ 36
+-
+-	th_comment_init @ 37
+-	th_comment_add @ 38
+-	th_comment_add_tag @ 39
+-	th_comment_query @ 40
+-	th_comment_query_count @ 41
+-	th_comment_clear @ 42
++EXPORTS
++; Old alpha API
++	theora_version_string @ 1
++	theora_version_number @ 2
++
++	theora_decode_header @ 3
++	theora_decode_init @ 4
++	theora_decode_packetin @ 5
++	theora_decode_YUVout @ 6
++
++	theora_control @ 7
++
++	theora_packet_isheader @ 8
++	theora_packet_iskeyframe @ 9
++
++	theora_granule_shift @ 10
++	theora_granule_frame @ 11
++	theora_granule_time @ 12
++
++	theora_info_init @ 13
++	theora_info_clear @ 14
++
++	theora_clear @ 15
++
++	theora_comment_init @ 16
++	theora_comment_add @ 17
++	theora_comment_add_tag @ 18
++	theora_comment_query @ 19
++	theora_comment_query_count @ 20
++	theora_comment_clear @ 21
++
++; New theora-exp API
++	th_version_string @ 22
++	th_version_number @ 23
++
++	th_decode_headerin @ 24
++	th_decode_alloc @ 25
++	th_setup_free @ 26
++	th_decode_ctl @ 27
++	th_decode_packetin @ 28
++	th_decode_ycbcr_out @ 29
++	th_decode_free @ 30
++
++	th_packet_isheader @ 31
++	th_packet_iskeyframe @ 32
++
++	th_granule_frame @ 33
++	th_granule_time @ 34
++
++	th_info_init @ 35
++	th_info_clear @ 36
++
++	th_comment_init @ 37
++	th_comment_add @ 38
++	th_comment_add_tag @ 39
++	th_comment_query @ 40
++	th_comment_query_count @ 41
++	th_comment_clear @ 42
+diff --git a/win32/xmingw32/libtheoraenc-all.def b/win32/xmingw32/libtheoraenc-all.def
+index 36d2dad..90130fd 100644
+--- a/win32/xmingw32/libtheoraenc-all.def
++++ b/win32/xmingw32/libtheoraenc-all.def
+@@ -1,17 +1,17 @@
+-EXPORTS
+-; Old alpha API
+-	theora_encode_init @ 1
+-	theora_encode_YUVin @ 2
+-	theora_encode_packetout @ 3
+-	theora_encode_header @ 4
+-	theora_encode_comment @ 5
+-	theora_encode_tables @ 6
+-; New theora-exp API
+-	th_encode_alloc @ 7
+-	th_encode_ctl @ 8
+-	th_encode_flushheader @ 9
+-	th_encode_ycbcr_in @ 10
+-	th_encode_packetout @ 11
+-	th_encode_free @ 12
+-	TH_VP31_QUANT_INFO @ 13
+-	TH_VP31_HUFF_CODES @ 14
++EXPORTS
++; Old alpha API
++	theora_encode_init @ 1
++	theora_encode_YUVin @ 2
++	theora_encode_packetout @ 3
++	theora_encode_header @ 4
++	theora_encode_comment @ 5
++	theora_encode_tables @ 6
++; New theora-exp API
++	th_encode_alloc @ 7
++	th_encode_ctl @ 8
++	th_encode_flushheader @ 9
++	th_encode_ycbcr_in @ 10
++	th_encode_packetout @ 11
++	th_encode_free @ 12
++	TH_VP31_QUANT_INFO @ 13
++	TH_VP31_HUFF_CODES @ 14
+-- 
+2.7.4
+


### PR DESCRIPTION
On gstreamer:
------------
- Also check for winpthread library

In new versions of mingw clock_gettime and other time functions
are not longer part of the standard library, they have been
moved to wipthread library instead
This patch applies a patch into gstreamer's configure.ac in
order to check if clock_gettime is being provided by winpthread

On libtheora:
------------
- Do not redefine rint function for mingw

All versions of mingw correctly define 'rint' function in
math.h
However, only newer versions complain about the function
redefinition when the -O option is greater than zero
(the redefinition of having a const version for something
that was previously non-const)
Cleanest solution is do not redefine this function for
GNU-C family of compiler and use the compiler's
version instead.

- Remove CR/LF in .de definition files.

Having CR/LF in .def files makes libtool not detect
the fist line with the 'EXPORTS' tag
(because it is actually EXPORTS\r), and at the end a new .def
file with 'EXPORTS' duplicated is generated.
Having 'EXPORTS' twice is not supported by newer mingw versions.
The most reasonable patch (instead of patching libtool) is
simply having the .def files properly formatted with LF only