### PR TITLE
Fix cfi checks for old compiler

### DIFF
--- a/recipes/libffi.recipe
+++ b/recipes/libffi.recipe
@@ -26,7 +26,8 @@ class Recipe(recipe.Recipe):
     commit = '60e4250a77eb3fde500bfd68ec40519fe34b21bd'
     licenses = [License.BSD_like]
     patches = ['libffi/0001-enable-pic-unix64-abort-call.patch',
-              'libffi/0002-disable-unsupported-deprecated-call.patch'
+              'libffi/0002-disable-unsupported-deprecated-call.patch',
+              'libffi/0003-enhance-cfi-support.patch'
               ]
 
     files_libs = ['libffi']

--- a/recipes/libffi/0003-enhance-cfi-support.patch
+++ b/recipes/libffi/0003-enhance-cfi-support.patch
@@ -1,0 +1,13 @@
+diff --git a/m4/asmcfi.m4 b/m4/asmcfi.m4
+index dbf73a0..3e28602 100644
+--- a/m4/asmcfi.m4
++++ b/m4/asmcfi.m4
+@@ -2,7 +2,7 @@ AC_DEFUN([GCC_AS_CFI_PSEUDO_OP],
+ [AC_CACHE_CHECK([assembler .cfi pseudo-op support],
+     gcc_cv_as_cfi_pseudo_op, [
+     gcc_cv_as_cfi_pseudo_op=unknown
+-    AC_TRY_COMPILE([asm (".cfi_startproc\n\t.cfi_endproc");],,
++    AC_TRY_COMPILE([asm (".cfi_sections\n\t.cfi_startproc\n\t.cfi_endproc");],,
+		   [gcc_cv_as_cfi_pseudo_op=yes],
+		   [gcc_cv_as_cfi_pseudo_op=no])
+  ])


### PR DESCRIPTION
cfi_sections can be unsupported when cfi_startproc
and cfi_endproc are.