### PR TITLE
rpm packager install lib in lib64

### DIFF
--- a/cerbero/packages/linux.py
+++ b/cerbero/packages/linux.py
@@ -39,6 +39,7 @@ class LinuxPackager(PackagerBase):
         self.package_prefix = self._package_prefix(self.package)
         self.full_package_name = self._full_package_name()
         self.packager = self.config.packager
+        self.lib64_link = False
         self._check_packager()
 
     def pack(self, output_dir, devel=True, force=False, keep_temp=False,
@@ -62,7 +63,7 @@ class LinuxPackager(PackagerBase):
             tarball_packager = DistArchive(self.config, self.package,
                                            self.store, ArchiveType.TARBALL)
             tarball = tarball_packager.pack(tmpdir, devel, True,
-                    split=False, package_prefix=self.full_package_name)[0]
+                    split=False, package_prefix=self.full_package_name, lib64_link=self.lib64_link)[0]
             tarname = self.setup_source(tarball, tmpdir, packagedir, srcdir)
         else:
             # metapackages only contains Requires dependencies with

--- a/cerbero/packages/rpm.py
+++ b/cerbero/packages/rpm.py
@@ -31,6 +31,7 @@ from cerbero.utils import shell, _
 SPEC_TPL = '''
 %%define _topdir %(topdir)s
 %%define _package_name %(package_name)s
+%%define _unpackaged_files_terminate_build 0
 
 Name:           %(p_prefix)s%(name)s
 Version:        %(version)s
@@ -147,6 +148,8 @@ class RPMPackager(LinuxPackager):
 
     def __init__(self, config, package, store):
         LinuxPackager.__init__(self, config, package, store)
+        if config.target_arch == Architecture.X86_64:
+          self.lib64_link = True
 
     def create_tree(self, tmpdir):
         # create a tmp dir to use as topdir
@@ -289,6 +292,8 @@ class RPMPackager(LinuxPackager):
                 files.append(f + 'c')
             if f + 'o' not in files:
                 files.append(f + 'o')
+        if self.config.target_arch == Architecture.X86_64:
+            files = [x.replace('lib/', 'lib64/') for x in files]
         return '\n'.join([os.path.join('%{prefix}',  x) for x in files])
 
     def _devel_package_and_files(self):


### PR DESCRIPTION
In order to support rpm distrib lib scheme,
need to install the libs in lib64