### PR TITLE
Go back to Mono 5.2.0 to fix bug of webkit thread still alive

### DIFF
--- a/recipes/mono/mono-windows.recipe
+++ b/recipes/mono/mono-windows.recipe
@@ -5,7 +5,7 @@ from cerbero.utils import shell
 
 class Recipe(recipe.Recipe):
     name = 'mono'
-    version = '5.12.0'
+    version = '5.2.0'
     licenses = [License.LGPL]
     stype = SourceType.CUSTOM
     btype = BuildType.CUSTOM


### PR DESCRIPTION
- When application quits even if we Destroy the webkit webviews
they still have threads alive making the application do not close.
this only happens in windows