### PR TITLE
Update gtk-sharp to 2.12.43

### DIFF
--- a/recipes/gtk-sharp/gtk-sharp-windows-2.0.recipe
+++ b/recipes/gtk-sharp/gtk-sharp-windows-2.0.recipe
@@ -4,7 +4,7 @@ from cerbero.utils import shell
 
 class Recipe(recipe.Recipe):
     name = 'gtk-sharp'
-    version = '2.12.42'
+    version = '2.12.43'
     licenses = [License.LGPL]
     stype = SourceType.CUSTOM
     btype = BuildType.CUSTOM


### PR DESCRIPTION
 It's still getting the dlls from the installed bin, but we should end up using the recipe for both systems