### PR TITLE
Allow configure Meson's builddir

### DIFF
--- a/cerbero/build/build.py
+++ b/cerbero/build/build.py
@@ -615,6 +615,7 @@ class Meson (Build, ModifyEnvBase) :
     meson_backend = 'ninja'
     # All meson recipes are MSVC-compatible, except if the code itself isn't
     can_msvc = True
+    meson_builddir = "_builddir"
 
     def __init__(self):
         self.meson_options = self.meson_options or {}
@@ -798,7 +799,7 @@ class Meson (Build, ModifyEnvBase) :
     @async_modify_environment
     async def configure(self):
         # self.build_dir is different on each call to configure() when doing universal builds
-        self.meson_dir = os.path.join(self.build_dir, "_builddir")
+        self.meson_dir = os.path.join(self.build_dir, self.meson_builddir)
         if os.path.exists(self.meson_dir):
             # Only remove if it's not empty
             if os.listdir(self.meson_dir):


### PR DESCRIPTION
For some special multilib recipes,
we need to change meson's _builddir
in order to configure in several
passes.