### PR TITLE
cerbero: Fix rlimit set exception

### DIFF
--- a/cerbero/config.py
+++ b/cerbero/config.py
@@ -61,12 +61,12 @@ def set_nofile_ulimit():
         import resource
     except ModuleNotFoundError:
         return
-    want = 10240
+    want = 2048
     soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
     if soft < want or hard < want:
         try:
             resource.setrlimit(resource.RLIMIT_NOFILE, (want, want))
-        except OSError:
+        except (OSError, ValueError):
             print('Failed to increase file ulimit, you may see linker failures')
 
 class Variants(object):


### PR DESCRIPTION
Decrease the desired value to 2048 as it's enough and
attempting to set it to higher values may fail on
some systems when running as a non-root user.