### PR TITLE
static: force rebuild of reverse deps for static recipes

### DIFF
--- a/cerbero/commands/fetch.py
+++ b/cerbero/commands/fetch.py
@@ -23,6 +23,7 @@ import asyncio
 
 from cerbero.commands import Command, register_command
 from cerbero.build.cookbook import CookBook
+from cerbero.enums import LibraryType
 from cerbero.errors import FatalError
 from cerbero.packages.packagesstore import PackagesStore
 from cerbero.utils import _, N_, ArgparseArgument, remove_list_duplicates, git, shell
@@ -80,7 +81,7 @@ class Fetch(Command):
                 if full_reset or not cookbook.recipe_needs_build(recipe.name):
                     to_rebuild.append(recipe)
                     cookbook.reset_recipe_status(recipe.name)
-                    if reset_rdeps:
+                    if recipe.library_type == LibraryType.STATIC or reset_rdeps:
                         for r in cookbook.list_recipe_reverse_deps(recipe.name):
                             to_rebuild.append(r)
                             cookbook.reset_recipe_status(r.name)


### PR DESCRIPTION
When a recipe that creates a static library is rebuilt,
all reverse dependencies should be rebuilt to pick the last changes.
For example, if libvpx is configured to generate a static library
and the recipe is rebuilt, gst-plugins-bad should all be rebuilt
so that the plugin is linked against the latest build of libvpx.