### PR TITLE
Fix cerbero for macOS Catalina

### DIFF
--- a/cerbero/enums.py
+++ b/cerbero/enums.py
@@ -122,6 +122,7 @@ class DistroVersion:
     OS_X_SIERRA = 'osx_sierra'
     OS_X_HIGH_SIERRA = 'osx_high_sierra'
     OS_X_MOJAVE = 'osx_mojave'
+    OS_X_CATALINA = 'osx_catalina'
     IOS_8_0 = 'ios_08_0'
     IOS_8_1 = 'ios_08_1'
     IOS_8_2 = 'ios_08_2'

--- a/cerbero/utils/__init__.py
+++ b/cerbero/utils/__init__.py
@@ -298,7 +298,9 @@ def system_info():
     elif platform == Platform.DARWIN:
         distro = Distro.OS_X
         ver = pplatform.mac_ver()[0]
-        if ver.startswith('10.14'):
+        if ver.startswith('10.15'):
+            distro_version = DistroVersion.OS_X_CATALINA
+        elif ver.startswith('10.14'):
             distro_version = DistroVersion.OS_X_MOJAVE
         elif ver.startswith('10.13'):
             distro_version = DistroVersion.OS_X_HIGH_SIERRA


### PR DESCRIPTION
Add enum entry and detection for the new macOS Catalina