### PR TITLE
bootstrap: Fix dnf usage on CentOS

### DIFF
--- a/cerbero/bootstrap/linux.py
+++ b/cerbero/bootstrap/linux.py
@@ -131,6 +131,8 @@ class RedHatBootstrapper (UnixBootstrapper):
 
         if self.config.distro_version < DistroVersion.FEDORA_23:
             self.tool = 'yum'
+        elif self.config.distro_version in [DistroVersion.REDHAT_6, DistroVersion.REDHAT_7]:
+            self.tool = 'yum'
 
         if self.config.target_platform == Platform.WINDOWS:
             self.packages.append('mingw-w64-tools')


### PR DESCRIPTION
CentOS 7.x (RHEL 7.x also) is based on Fedora 19 and it uses yum
as a default package manager.