### PR TITLE
cerbero: Fix setting of git credentials

### DIFF
--- a/cerbero/utils/git.py
+++ b/cerbero/utils/git.py
@@ -218,7 +218,7 @@ def local_checkout(git_dir, local_git_dir, commit, logfile=None):
     shell.call('%s reset --hard %s' % (GIT, commit), local_git_dir, logfile=logfile)
     shell.call('%s clone %s -s -b %s .' % (GIT, local_git_dir, branch_name),
                git_dir, logfile=logfile)
-    ensure_user_is_set(local_git_dir, logfile=logfile)
+    ensure_user_is_set(git_dir, logfile=logfile)
     submodules_update(git_dir, local_git_dir, logfile=logfile)
 
 def add_remote(git_dir, name, url, logfile=None):


### PR DESCRIPTION
The git credentials need to be set in the repo we're cloning into, not
the repo we're cloning from.

From: https://gitlab.freedesktop.org/gstreamer/cerbero/commit/42db9ec6c8e3f75b41b94cc39077adbf9972f4b6