### PR TITLE
Add cache command to inspect and modify local cache

### DIFF
--- a/cerbero/build/cookbook.py
+++ b/cerbero/build/cookbook.py
@@ -59,7 +59,7 @@ class RecipeStatus (object):
     '''
 
     def __init__(self, filepath, steps=[], needs_build=True,
-                 mtime=time.time(), built_version=None, file_hash=0):
+                 mtime=time.time(), built_version='', file_hash=0):
         self.steps = steps
         self.needs_build = needs_build
         self.mtime = mtime
@@ -72,7 +72,8 @@ class RecipeStatus (object):
         self.mtime = time.time()
 
     def __repr__(self):
-        return "Steps: %r Needs Build: %r" % (self.steps, self.needs_build)
+        return "steps: %r, needs_build: %r, mtime: %r, filepath: %r, built_version: %r, file_hash: %r" % \
+            (self.steps, self.needs_build, self.mtime, self.filepath, self.built_version, self.file_hash.hex())
 
 
 class CookBook (object):

--- a/cerbero/commands/edit_cache.py
+++ b/cerbero/commands/edit_cache.py
@@ -1,0 +1,114 @@
+# cerbero - a multi-platform build system for Open Source software
+# Copyright (C) 2019, Fluendo, S.A.
+#  Author: Pablo Marcos Oltra <pmarcos@fluendo.com>, Fluendo, S.A.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+
+from cerbero.commands import Command, register_command
+from cerbero.build.cookbook import CookBook, RecipeStatus
+from cerbero.utils import _, N_, ArgparseArgument
+from cerbero.utils import messages as m
+
+
+class EditCache(Command):
+    # The edit-cache command takes the `RecipeStatus` class and analyzes its
+    # attributes using introspection to expose its members and allow modifying
+    # them trough the command line. The type of the arguments is the same as the
+    # ones in `RecipeStatus` except for the boolean values, that are passed
+    # using a string containing either "True" or "False". This is done for
+    # consistency and to avoid having two different arguments such as --feature
+    # and --no-feature
+    doc = N_('View and edit the local cache')
+    name = 'edit-cache'
+
+    def __init__(self):
+        self.recipe_status = RecipeStatus('filepath')
+        self.recipe_attributes = list(set(dir(self.recipe_status)) - set(dir(RecipeStatus)))
+        arguments = [
+            ArgparseArgument('recipe', nargs='*',
+                             help=_('Recipe to work with')),
+            ArgparseArgument('--bootstrap', action='store_true', default=False,
+                             help=_('Use bootstrap\'s cache file')),
+            ArgparseArgument('--touch', action='store_true', default=False,
+                             help=_('Touch recipe modifying its mtime')),
+            ArgparseArgument('--reset', action='store_true', default=False,
+                             help=_('Clean entirely the cache for the recipe'))
+        ]
+
+        for attr in self.recipe_attributes:
+            attr_nargs = '*' if isinstance(getattr(self.recipe_status, attr), list) else None
+            attr_type = type(getattr(self.recipe_status, attr))
+            arguments.append(
+                ArgparseArgument('--' + attr, nargs=attr_nargs, type=str if attr_type == bool else attr_type,
+                                 help=_('Modify ' + attr))
+            )
+        Command.__init__(self, arguments)
+
+    def run(self, config, args):
+        if args.bootstrap:
+            config.cache_file = config.build_tools_cache
+        cookbook = CookBook(config)
+
+        is_modifying = False or args.touch or args.reset
+        if not is_modifying:
+            for attr in self.recipe_attributes:
+                if getattr(args, attr):
+                    is_modifying = True
+                    break
+
+        global_status = cookbook.status
+        recipes = args.recipe or list(global_status.keys())
+
+        m.message('{} cache values for recipes: {}'.format(
+            'Showing' if not is_modifying else 'Modifying', ', '.join(recipes)))
+
+        for recipe in recipes:
+            if recipe not in global_status.keys():
+                m.error('Recipe {} not in cookbook'.format(recipe))
+                continue
+            status = global_status[recipe]
+            print('[{}]'.format(recipe))
+            text = ''
+            if is_modifying:
+                text = 'Before\n'
+            print('{}{}\n'.format(text, status))
+            if is_modifying:
+                if args.reset:
+                    cookbook.reset_recipe_status(recipe)
+                    m.message('Recipe {} reset'.format(recipe))
+                else:
+                    if args.touch:
+                        status.touch()
+
+                    for attr in self.recipe_attributes:
+                        var = getattr(args, attr)
+                        if var:
+                            if isinstance(getattr(self.recipe_status, attr), bool):
+                                if var.lower() == 'true':
+                                    var = True
+                                elif var.lower() == 'false':
+                                    var = False
+                                else:
+                                    m.error('Error: Attribute "{}" needs to be either "True" or "False"'.format(attr))
+                                    return
+                            setattr(status, attr, var)
+
+                    cookbook.save()
+                    print('After\n{}\n'.format(status))
+
+
+register_command(EditCache)


### PR DESCRIPTION
This `cache` command is meant to be used during development to ease and speed up testing and figuring out issues.
The key idea is to have an inspector and modifier of cookbook's status that `pickle` serializes/deserializes to/from both for  `build-tools.cache` and `linux_x86_64.cache` (on Linux).

Usage:
```
usage: cerbero-uninstalled cache [-h] [--bootstrap]
                                 [--steps [STEPS [STEPS ...]]]
                                 [--needs_build NEEDS_BUILD] [--mtime MTIME]
                                 [--file_path FILE_PATH]
                                 [--built_version BUILT_VERSION]
                                 [--file_hash FILE_HASH] [--touch]
                                 [recipe [recipe ...]]

positional arguments:
  recipe                Recipe to work with

optional arguments:
  -h, --help            show this help message and exit
  --bootstrap           Use bootstrap's cache file
  --steps [STEPS [STEPS ...]]
                        Modify steps
  --needs_build NEEDS_BUILD
                        Modify needs_build
  --mtime MTIME         Modify mtime
  --file_path FILE_PATH
                        Modify file_path
  --built_version BUILT_VERSION
                        Modify built_version
  --file_hash FILE_HASH
                        Modify file_hash
  --touch               Touch recipe modifying its mtime
```

e.g. inspecting a recipe's status
```
./cerbero-uninstalled -t cache libffi       
0:00:00.001577 Loading default configuration from /home/pablo/.cerbero/cerbero.cbc
0:00:00.267447 Showing cache values for recipes: libffi
[libffi]
steps: ['fetch', 'extract', 'configure', 'compile', 'install', 'post_install'], needs_build: False, mtime: 1573815322.381322, filepath: '/home/pablo/Fluendo/fluendo-cerbero/cerbero/recipes/libffi.recipe', built_version: '3.2.9999+git~369ef49f71186fc9d6ab15614488ad466fac3fc1', file_hash: '80cd4a1c0feb7da8eab4862c30642b21'
```

e.g. modifying a recipe's status
```
./cerbero-uninstalled -t cache libffi --needs_build True --steps fetch extract 
0:00:00.001619 Loading default configuration from /home/pablo/.cerbero/cerbero.cbc
0:00:00.253475 Modifying cache values for recipes: libffi
[libffi]
Before
steps: ['fetch', 'extract', 'configure', 'compile', 'install', 'post_install'], needs_build: False, mtime: 1573815322.381322, filepath: '/home/pablo/Fluendo/fluendo-cerbero/cerbero/recipes/libffi.recipe', built_version: '3.2.9999+git~369ef49f71186fc9d6ab15614488ad466fac3fc1', file_hash: '80cd4a1c0feb7da8eab4862c30642b21'

After
steps: ['fetch', 'extract'], needs_build: True, mtime: 1573815322.381322, filepath: '/home/pablo/Fluendo/fluendo-cerbero/cerbero/recipes/libffi.recipe', built_version: '3.2.9999+git~369ef49f71186fc9d6ab15614488ad466fac3fc1', file_hash: '80cd4a1c0feb7da8eab4862c30642b21'
```