### PR TITLE
Fix not strip files in centos7

### DIFF
--- a/cerbero/packages/rpm.py
+++ b/cerbero/packages/rpm.py
@@ -32,7 +32,8 @@ from functools import reduce
 SPEC_TPL = '''
 %%define _topdir %(topdir)s
 %%define _package_name %(package_name)s
-%%define debug_package %%{nil}
+%undefine _debugsource_packages
+%undefine _debuginfo_subpackages
 
 Name:           %(p_prefix)s%(name)s
 Version:        %(version)s


### PR DESCRIPTION
If `%define debug_package %{nil}` is used then `%__spec_install_post` doesn’t
include `__debug_install_post`. And `__debug_install_post` includes the
execution of `/usr/lib/rpm/find-debuginfo.sh`, which it is the one
that extracts debug info from bins and libs.

Code from /usr/lib/rpm/macros

```
%__spec_install_post\
%{?__debug_package:%{__debug_install_post}}\
%{__arch_install_post}\
%{__os_install_post}\
%{nil}
```

Undefining `_debugsource_packages` and `_debuginfo_subpackages` the debuginfo
and debugsource RPM packages are not generated and the rpmbuild process keeps
extracting debug info from the files (`find-debuginfo.sh` is called).