### PR TITLE
Use lib_suffix in filesprovider

### DIFF
--- a/cerbero/build/filesprovider.py
+++ b/cerbero/build/filesprovider.py
@@ -369,7 +369,7 @@ class FilesProvider(object):
         '''
         if self.library_type == LibraryType.STATIC:
             return {}
-        libdir = self.extensions['sdir']
+        libdir = self.extensions['sdir'] + self.config.lib_suffix
         libext = self.extensions['srext']
         libregex = self.extensions['sregex']
         if libregex:


### PR DESCRIPTION
Necessary to use /lib/lib64 in centos