### PR TITLE
rpm: Use nodebuginfo option in rpmbuild when exist

### DIFF
--- a/cerbero/packages/rpm.py
+++ b/cerbero/packages/rpm.py
@@ -21,6 +21,7 @@ import shutil
 import tempfile
 
 from cerbero.config import Architecture
+from cerbero.enums import Distro, DistroVersion
 from cerbero.errors import FatalError, EmptyPackageError
 from cerbero.packages import PackageType
 from cerbero.packages.linux import LinuxPackager
@@ -243,8 +244,15 @@ class RPMPackager(LinuxPackager):
         else:
             raise FatalError(_('Architecture %s not supported') % \
                              self.config.target_arch)
-        shell.call('rpmbuild -bb --buildroot %s/buildroot --target %s %s' % (tmpdir,
-            target, self.spec_path))
+
+        extra_options = ''
+        if (self.config.distro == Distro.REDHAT and
+            (self.config.distro_version > DistroVersion.REDHAT_7 or
+             self.config.distro_version > DistroVersion.FEDORA_26)):
+            extra_options = '--nodebuginfo'
+
+        shell.call('rpmbuild -bb %s --buildroot %s/buildroot --target %s %s' % (
+            extra_options, tmpdir, target, self.spec_path))
 
         paths = []
         for d in os.listdir(packagedir):


### PR DESCRIPTION
Fix:
```
rpmbuild -bb --buildroot /workspace/tmpn0_oh6lc/buildroot --target x86_64-redhat-linux /workspace/tmpn0_oh6lc/ffmpeg-fluendo-gst-1.0.spec
...
error: Empty %files file /opt/ffmpeg-fluendo-gst-ci-1.0-redhat_8-x86_64/tmpn0_oh6lc/BUILD/ffmpeg-fluendo-gst-1.0-1.0.8.2/debugfiles.list

RPM build errors:
    Empty %files file /opt/ffmpeg-fluendo-gst-ci-1.0-redhat_8-x86_64/tmpn0_oh6lc/BUILD/ffmpeg-fluendo-gst-1.0-1.0.8.2/debugfiles.list
```

Commit 100ed216cd7ae72074bed48c73cc3d8bd2e571cb fixed `Empty %files file ...debugsourcefiles.list`. Now the problem is with `debugfiles.list`