### PR TITLE
rpm: fix distro_version comparison

### DIFF
--- a/cerbero/packages/rpm.py
+++ b/cerbero/packages/rpm.py
@@ -246,9 +246,7 @@ class RPMPackager(LinuxPackager):
                              self.config.target_arch)
 
         extra_options = ''
-        if (self.config.distro == Distro.REDHAT and
-            (self.config.distro_version > DistroVersion.REDHAT_7 or
-             self.config.distro_version > DistroVersion.FEDORA_26)):
+        if self._rpmbuild_support_nodebuginfo():
             extra_options = '--nodebuginfo'
 
         shell.call('rpmbuild -bb %s --buildroot %s/buildroot --target %s %s' % (
@@ -263,6 +261,20 @@ class RPMPackager(LinuxPackager):
                 paths.append(out_path)
                 shutil.move(os.path.join(packagedir, d, f), output_dir)
         return paths
+
+    def _rpmbuild_support_nodebuginfo(self):
+        if not self.config.distro == Distro.REDHAT:
+            return False
+
+        if ("fedora" in self.config.distro_version
+           and self.config.distro_version > DistroVersion.FEDORA_26):
+            return True
+
+        if ("redhat" in self.config.distro_version
+           and self.config.distro_version > DistroVersion.REDHAT_7):
+            return True
+
+        return False
 
     def _get_meta_requires(self, package_type):
         devel_suffix = ''


### PR DESCRIPTION
Strings algebra problem

```
"redhat_6" > "fedora_26"
```