### PR TITLE
Prepend $CERBERO_PREFIX/lib path in LD_LIBRARY_PATH

### DIFF
--- a/cerbero/config.py
+++ b/cerbero/config.py
@@ -350,7 +350,7 @@ class Config (object):
         ld_library_path = self._join_path(
             os.path.join(self.build_tools_prefix, 'lib'), path)
         if not self.cross_compiling():
-            ld_library_path = self._join_path(ld_library_path, libdir)
+            ld_library_path = self._join_path(libdir, ld_library_path)
         if self.extra_lib_path is not None:
             ld_library_path = self._join_path(ld_library_path, self.extra_lib_path)
         if self.toolchain_prefix is not None:


### PR DESCRIPTION
When not cross-compiling, $CERBERO_PREFIX/lib path was added at the end
of LD_LIBRARY_PATH whereas build-tools/lib path was prepended. As a
consequence, libraries and tools installed during bootstrap were taking
precedence over the one built later within the prefix (for libraries and
tools available at both places). This happens for example with glib when
it is installed during bootstrap (glib-tools.recipe) and built later as
a dependency (glib.recipe). This commit prepends $CERBERO_PREFIX/lib in
LD_LIBRARY_PATH in order to use the build-tools/lib when no dependency
is custom built, and then to use the $CERBERO_PREFIX/lib once the
dependency has been correctly built. It also brings coherency with PATH
variable order as $CERBERO_PREFIX/bin preceeds build-tools/bin.