### PR TITLE
Fix after fridge merge

### DIFF
--- a/cerbero/build/cookbook.py
+++ b/cerbero/build/cookbook.py
@@ -409,11 +409,6 @@ class CookBook (object):
                 else:
                     self.reset_recipe_status(recipe.name)
 
-    async def _async_reset_recipe_if_needed(self, recipe, st):
-        await recipe.async_built_version()
-        print('Recipe {} -> {}'.format(recipe.name, recipe.built_version()))
-        self._reset_recipe_if_needed(recipe, st)
-
     def _load_recipes(self):
         self.recipes = {}
         recipes = defaultdict(dict)

--- a/cerbero/build/cookbook.py
+++ b/cerbero/build/cookbook.py
@@ -443,7 +443,7 @@ class CookBook (object):
                 st.mtime = 0;
             recipe.run_func_depending_on_built_version(async_tasks, self._reset_recipe_if_needed, recipe, st)
 
-        asyncio.get_event_loop().run_until_complete(asyncio.gather(*async_tasks))
+        shell.run_until_complete(async_tasks)
 
     def _load_recipes_from_dir(self, repo):
         recipes = {}

--- a/cerbero/packages/packagesstore.py
+++ b/cerbero/packages/packagesstore.py
@@ -172,7 +172,7 @@ class PackagesStore (object):
                 continue
             recipe.run_func_depending_on_built_version(async_tasks, self._load_package_from_recipe, recipe)
 
-        asyncio.get_event_loop().run_until_complete(asyncio.gather(*async_tasks))
+        shell.run_until_complete(async_tasks)
 
     def _package_from_recipe(self, recipe):
         p = package.Package(self._config, self, self.cookbook)

--- a/cerbero/utils/shell.py
+++ b/cerbero/utils/shell.py
@@ -31,6 +31,7 @@ import glob
 import shutil
 import hashlib
 import urllib.request, urllib.error, urllib.parse
+import math
 from ftplib import FTP
 from pathlib import Path, PurePath
 from distutils.version import StrictVersion
@@ -743,3 +744,8 @@ def windows_proof_rename(from_name, to_name):
                 continue
     # Try one last time and throw an error if it fails again
     os.rename(from_name, to_name)
+
+def run_until_complete(tasks, max_concurrent=64):
+    slices = [tasks[i*max_concurrent:i*max_concurrent+max_concurrent] for i in range(math.ceil(len(tasks) / max_concurrent))]
+    for s in slices:
+        asyncio.get_event_loop().run_until_complete(asyncio.gather(*s))


### PR DESCRIPTION
Ensure that at most 64 concurrent `git ls-remote` are run to avoid Bitbucket refusing requests