### PR TITLE
Fix to allow catching exceptions in git.get_hash()

### DIFF
--- a/cerbero/build/source.py
+++ b/cerbero/build/source.py
@@ -337,8 +337,11 @@ class GitCache (Source):
 
     async def async_built_version(self):
         if not self.cached_built_version:
-            git_hash = await git.async_get_hash(self.repo_dir, self.commit, self.remotes)
-            self.cached_built_version = '%s+git~%s' % (self.version, git_hash)
+            git_hash = 'error_getting_hash'
+            try:
+                git_hash = await git.async_get_hash(self.repo_dir, self.commit, self.remotes)
+            finally:
+                self.cached_built_version = '%s+git~%s' % (self.version, git_hash)
         return self.cached_built_version
 
     def built_version(self):


### PR DESCRIPTION
We need to make sure the recipe.cached_built_version is always set because otherwise PackagesStore._package_from_recipe will attempt to run an even loop within an existing loop when calling recipe.built_version().