### PR TITLE
Update LD_LIBRARY_PATH when the prefix is executable and PATH is updated

### DIFF
--- a/cerbero/config.py
+++ b/cerbero/config.py
@@ -354,7 +354,7 @@ class Config (object):
 
         ld_library_path = self._join_path(
             os.path.join(self.build_tools_prefix, 'lib'), path)
-        if not self.cross_compiling():
+        if self.prefix_is_executable():
             ld_library_path = self._join_path(libdir, ld_library_path)
         if self.extra_lib_path is not None:
             ld_library_path = self._join_path(ld_library_path, self.extra_lib_path)


### PR DESCRIPTION
Cross compiling for Linux x86 inside x86_64 the prefix is executable and
the PATH is updated with bindir (`/build/dist/linux_x86/bin`), but
LD_LIBRARY_PATH is not updated with libdir (`/build/dist/linux_x86/lib`).
Same logic to add to PATH should be done to add to LD_LIBRARY_PATH.

Error fixed:
```
./cerbero-uninstalled -t -c cross-linux-x86.cbc build freetype
...
0:05:11.642423 -----> Extracting tarball to /build/sources/linux_x86/freetype-2.9
bzip2: error while loading shared libraries: libbz2.so.1: cannot open shared object file: No such file or directory
tar: Child returned status 127
tar: Error is not recoverable: exiting now
...
```

Inside the shell
```
ldd /build/dist/linux_x86/bin/bzip2
    linux-gate.so.1 =>  (0xf7f17000)
    libbz2.so.1 => not found
    libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7d49000)
    /lib/ld-linux.so.2 (0xf7f18000)

```