### PR TITLE
Fix for non-existing self_update args

### DIFF
--- a/cerbero/main.py
+++ b/cerbero/main.py
@@ -126,7 +126,7 @@ class Main(object):
     def self_update(self):
         '''Update this instance of cerbero git repository'''
 
-        if not self.args.self_update:
+        if not hasattr(self.args, "self_update"):
            return
 
         try:


### PR DESCRIPTION
In case argv[0] is not 'cerbero-uninstalled', the self_update arg is never added. This fix allow us to run cerbero in profilers such as scalene without the error:

```
Scalene: An exception of type AttributeError occurred. Arguments:
("'Namespace' object has no attribute 'self_update'",)
Traceback (most recent call last):
  File "/home/pablo/.local/lib/python3.6/site-packages/scalene/scalene.py", line 454, in main
    exec(code, the_globals)
  File "./cerbero-uninstalled", line 14, in <module>
    main()
  File "./cerbero/cerbero/main.py", line 196, in main
    Main(sys.argv[1:])
  File "./cerbero/cerbero/main.py", line 62, in __init__
    self.self_update()
  File "./cerbero/cerbero/main.py", line 129, in self_update
    if not self.args.self_update:
AttributeError: 'Namespace' object has no attribute 'self_update'
```