### PR TITLE
cmake: Fix error with cmake recipes with use_system_libs

### DIFF
--- a/cerbero/build/build.py
+++ b/cerbero/build/build.py
@@ -531,7 +531,6 @@ class CMake (MakefilesBase):
                     '-DCMAKE_FIND_ROOT_PATH=$CERBERO_PREFIX '\
                     '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true '
 
-    @async_modify_environment
     async def configure(self):
         cc = self.env.get('CC', 'gcc')
         cxx = self.env.get('CXX', 'g++')


### PR DESCRIPTION
Error:
```
Traceback (most recent call last):
  File "./cerbero/cerbero/build/oven.py", line 202, in _cook_recipe
    loop.run_until_complete(stepfunc(recipe))
  File "/usr/lib/python3.6/asyncio/base_events.py", line 484, in run_until_complete
    return future.result()
  File "./cerbero/cerbero/build/recipe.py", line 54, in wrapped
    await ret
  File "./cerbero/cerbero/build/build.py", line 170, in call
    res = await func(*args)
  File "./cerbero/cerbero/build/build.py", line 573, in configure
    await MakefilesBase.configure(self)
  File "./cerbero/cerbero/build/build.py", line 168, in call
    self._add_system_libs()
  File "./cerbero/cerbero/build/build.py", line 327, in _add_system_libs
    self.set_env(var, val)
  File "./cerbero/cerbero/build/build.py", line 260, in set_env
    self.check_reentrancy()
  File "./cerbero/cerbero/build/build.py", line 247, in check_reentrancy
    raise RuntimeError('Do not modify the env inside @modify_environment, it will have no effect')
RuntimeError: Do not modify the env inside @modify_environment, it will have no effect
```