### PR TITLE
Fix CMake issue with older versions

### DIFF
--- a/cerbero/build/build.py
+++ b/cerbero/build/build.py
@@ -397,7 +397,8 @@ class MakefilesBase (Build, ModifyEnvBase):
             'target': self.config.target,
             'build': self.config.build,
             'options': self.configure_options,
-            'build_dir': to_unixpath(self.build_dir)}
+            'build_dir': to_unixpath(self.build_dir),
+            'make_dir': to_unixpath(self.make_dir)}
 
         await shell.async_call(configure_cmd, self.make_dir,
                                logfile=self.logfile, env=self.env)
@@ -522,7 +523,7 @@ class CMake (MakefilesBase):
     config_sh = 'cmake'
     configure_tpl = '%(config-sh)s -DCMAKE_INSTALL_PREFIX=%(prefix)s ' \
                     '-S %(build_dir)s ' \
-                    '-B %(build_dir)s ' \
+                    '-B %(make_dir)s ' \
                     '-DCMAKE_LIBRARY_OUTPUT_PATH=%(libdir)s ' \
                     '-DCMAKE_INSTALL_LIBDIR=%(libdir)s ' \
                     '-DCMAKE_INSTALL_BINDIR=%(prefix)s/bin ' \

--- a/cerbero/build/build.py
+++ b/cerbero/build/build.py
@@ -522,8 +522,8 @@ class CMake (MakefilesBase):
 
     config_sh = 'cmake'
     configure_tpl = '%(config-sh)s -DCMAKE_INSTALL_PREFIX=%(prefix)s ' \
-                    '-S %(build_dir)s ' \
-                    '-B %(make_dir)s ' \
+                    '-H%(build_dir)s ' \
+                    '-B%(make_dir)s ' \
                     '-DCMAKE_LIBRARY_OUTPUT_PATH=%(libdir)s ' \
                     '-DCMAKE_INSTALL_LIBDIR=%(libdir)s ' \
                     '-DCMAKE_INSTALL_BINDIR=%(prefix)s/bin ' \


### PR DESCRIPTION
CMake 3.10.2 has some weird behavior that we can extrapolate to some other old versions:
    
- Old CMake versions don't support -S, so we use -H instead
- Old CMake versions don't work with whitespace after -H or -B