### PR TITLE
Only the dev pkg should contain symlinks for shared libraries w/o version number

### DIFF
--- a/cerbero/build/filesprovider.py
+++ b/cerbero/build/filesprovider.py
@@ -123,7 +123,9 @@ class FilesProvider(object):
     # UNIX shared libraries can have between 0 and 3 version components:
     # major, minor, micro. We don't use {m,n} here because we want to capture
     # all the matches.
-    _SO_REGEX = r'^{}\.so((\.[0-9]+)+)?$'
+    _ANDROID_SO_REGEX = r'^{}\.so((\.[0-9]+)+)?$'
+    # Like _ANDROID_SO_REGEX but only libs with version number.
+    _LINUX_SO_REGEX = r'^{}\.so(\.[0-9]+)((\.[0-9]+)+)?$'
     _DYLIB_REGEX = r'^{}(-|\.)(([0-9]+\.)+)?dylib$'
 
     # Extension Glob Legend:
@@ -137,9 +139,9 @@ class FilesProvider(object):
     EXTENSIONS = {
         Platform.WINDOWS: {'bext': '.exe', 'sregex': _DLL_REGEX, 'sdir': 'bin',
             'mext': '.dll', 'smext': '.a', 'pext': '.pyd', 'srext': '.dll'},
-        Platform.LINUX: {'bext': '', 'sregex': _SO_REGEX, 'sdir': 'lib',
+        Platform.LINUX: {'bext': '', 'sregex': _LINUX_SO_REGEX, 'sdir': 'lib',
             'mext': '.so', 'smext': '.a', 'pext': '.so', 'srext': '.so'},
-        Platform.ANDROID: {'bext': '', 'sregex': _SO_REGEX, 'sdir': 'lib',
+        Platform.ANDROID: {'bext': '', 'sregex': _ANDROID_SO_REGEX, 'sdir': 'lib',
             'mext': '.so', 'smext': '.a', 'pext': '.so', 'srext': '.so'},
         Platform.DARWIN: {'bext': '', 'sregex': _DYLIB_REGEX, 'sdir': 'lib',
             'mext': '.so', 'smext': '.a', 'pext': '.so', 'srext': '.dylib'},


### PR DESCRIPTION
Currently the main packages generetad with cerbero contain symlinks for
shared libraries without version number. For instance, executing:

```
./cerbero-uninstalled package base-system-1.0
```

The `base-system-1.0_1.16.1-1_amd64.deb` contains symlinks like
`libturbojpeg.so`, `libxml2.so` or `libz.so`.

These symlinks are also in the development package. And there is an error when the development
package is installed because the system tries to overwrite a file, which was installed by
the main package.

From debian site:
https://www.debian.org/doc/manuals/maint-guide/advanced.en.html

> Please note that the development package should contain a symlink for the
> associated shared library without a version number.
> E.g.: /usr/lib/x86_64-linux-gnu/libfoo.so -> libfoo.so.1

From the fedora site:
https://fedoraproject.org/wiki/Archive:BuildingPackagesGuide?rd=Docs/Drafts/BuildingPackagesGuide

> All headers, static libraries, libtool archives, *.so files, autotools,
> and pkgconfig files go in the -devel subpackage.

With a git bisect, looks like ba26e9c0 is the first bad commit.