### PR TITLE
Add custom step that removes rpath from binaries on linux

### DIFF
--- a/cerbero/build/recipe.py
+++ b/cerbero/build/recipe.py
@@ -136,7 +136,7 @@ class BuildSteps(object):
     GEN_LIBFILES = (N_('Gen Library File'), 'gen_library_file')
     MERGE = (N_('Merge universal binaries'), 'merge')
     RELOCATE_OSX_LIBRARIES = (N_('Relocate OSX libraries'), 'relocate_osx_libraries')
-    DELETE_RPATH = (N_('Delate rpath from binaries'), 'delete_rpath')
+    DELETE_RPATH = (N_('Delete rpath from binaries'), 'delete_rpath')
 
     def __new__(cls):
         return [BuildSteps.FETCH, BuildSteps.EXTRACT,


### PR DESCRIPTION
Step 'delete_rpath' is custom and might be activated by setting
extra_property['no_rpath'] to True in the cbc. When this is done, all
installed ELF files that are specified in the recipe will have the rpath
removed.

More info from task description:
https://fluendo.atlassian.net/browse/OCP-1353

I'm also going to create a marge request to upstream cerbero. 