### PR TITLE
Fix tarball packages not being stripped correctly

### DIFF
--- a/cerbero/commands/package.py
+++ b/cerbero/commands/package.py
@@ -117,15 +117,9 @@ class Package(Command):
         output_dir = os.path.abspath(args.output_dir)
         if args.no_split:
             args.no_devel = False
-        if args.tarball:
-            paths = pkg.pack(output_dir, args.no_devel,
-                             args.force, args.keep_temp,
-                             not args.no_split,
-                             strip_binaries=p.strip)
-        else:
-            paths = pkg.pack(output_dir, args.no_devel,
-                             args.force, args.keep_temp,
-                             not args.no_split)
+        paths = pkg.pack(output_dir, args.no_devel,
+                         args.force, args.keep_temp,
+                         not args.no_split)
         if None in paths:
             paths.remove(None)
         paths = p.post_package(paths, output_dir) or paths

--- a/cerbero/packages/disttarball.py
+++ b/cerbero/packages/disttarball.py
@@ -169,8 +169,8 @@ class DistTarball(PackagerBase):
 
         for f in files:
             filepath = os.path.join(self.prefix, f)
-            stat = os.stat(filepath)
             if relocatable and not os.path.islink(filepath):
+                stat = os.stat(filepath)
                 if is_text_file(filepath) and stat.st_ino not in inodes_copied:
                     if stat.st_nlink > 1:
                         inodes_copied.append(stat.st_ino)

--- a/cerbero/packages/disttarball.py
+++ b/cerbero/packages/disttarball.py
@@ -73,7 +73,7 @@ class DistTarball(PackagerBase):
         return dist_files, devel_files
 
     def pack(self, output_dir, devel=True, force=False, keep_temp=False, split=True,
-             package_prefix='', strip_binaries=False, force_empty=False,
+             package_prefix='', strip_binaries=None, force_empty=False,
              relocatable=False, lib64_link=False):
         PackagerBase.pack(self, output_dir, devel, force, keep_temp, split)
         dist_files = []
@@ -83,6 +83,7 @@ class DistTarball(PackagerBase):
         except EmptyPackageError:
             pass
         filenames = []
+        strip_binaries = strip_binaries if strip_binaries is not None else self.package.strip
         create_tarball_func = self._create_tarball if not strip_binaries else self._create_tarball_stripped
         if dist_files or force_empty:
             runtime = create_tarball_func(output_dir, PackageType.RUNTIME,

--- a/cerbero/packages/linux.py
+++ b/cerbero/packages/linux.py
@@ -68,7 +68,8 @@ class LinuxPackager(PackagerBase):
                 tarball_packager = DistTarball(self.config, self.package,
                                                self.store)
                 tarball = tarball_packager.pack(tmpdir, devel, True,
-                                                split=False, package_prefix=self.full_package_name)[0]
+                                                split=False, package_prefix=self.full_package_name,
+                                                strip_binaries=False)[0]
                 tarname = self.setup_source(tarball, tmpdir, packagedir, srcdir)
             else:
                 # Metapackages only contains Requires dependencies with


### PR DESCRIPTION
* Fix api usage when packaging a stripped tarball

The usage of pack method in package.py was a too complex. It was done
to do not strip packages when creating a tarball for rpm or debian
packages. Now the pack API usage is simpler and the Linux packager
directly specifies that tarball should not be stripped.

* Fix creating a splitted tarball packages.

Trying to do a stat on a symbolic link linking to a path that does not
exist (like .so files in devel pacakges) ended with an error:

```
~/Workspace/fluendo-cerbero$ ./cerbero-uninstalled -c
./projects/openh264/openh264-release.cbc package openh264 --tarball

...

-----> Creating package for openh264
['lib/libopenh264.so.1.8.0', 'lib/libopenh264.so.4']
Traceback (most recent call last):
  File "./cerbero-uninstalled", line 14, in <module>
    main()
  File "./cerbero/cerbero/main.py", line 195, in main
    Main(sys.argv[1:])
  File "./cerbero/cerbero/main.py", line 66, in __init__
    self.run_command()
  File "./cerbero/cerbero/main.py", line 164, in run_command
    res = commands.run(command, self.config, self.args)
  File "./cerbero/cerbero/commands/__init__.py", line 78, in run
    return _commands[command].run(config, args)
  File "./cerbero/cerbero/commands/package.py", line 122, in run
    not args.no_split)
  File "./cerbero/cerbero/packages/disttarball.py", line 98, in pack
    relocatable, lib64_link)
  File "./cerbero/cerbero/packages/disttarball.py", line 150, in _create_tarball_stripped
    relocatable, lib64_link)
  File "./cerbero/cerbero/packages/disttarball.py", line 174, in _create_tarball
    stat = os.stat(filepath)
FileNotFoundError: [Errno 2] No such file or directory:
'/opt/openh264-release_linux_linux_x86_64/tmp6b3_kj3x/lib/libopenh264.so'
~/Workspace/fluendo-cerbero$ ll /opt/openh264-release_linux_linux_x86_64/tmp6b3_kj3x/lib/libopenh264.so
lrwxrwxrwx 1 molejnik molejnik 16 Mar 16 19:16 /opt/openh264-release_linux_linux_x86_64/tmp6b3_kj3x/lib/libopenh264.so -> libopenh264.so.4
```
