### PR TITLE
Use the correct pack args based on the package type

### DIFF
--- a/cerbero/commands/package.py
+++ b/cerbero/commands/package.py
@@ -117,7 +117,7 @@ class Package(Command):
         output_dir = os.path.abspath(args.output_dir)
         if args.no_split:
             args.no_devel = False
-        if args.tarball:
+        if isinstance(pkg, DistTarball):
             paths = pkg.pack(output_dir, args.no_devel,
                              args.force, args.keep_temp,
                              not args.no_split,


### PR DESCRIPTION
This should never happen, all implementation should have the same
method signature. If someone needs a different pack function
it should create a new method