### PR TITLE
COM-1108 Fix PATH inclusion to LD_LIBRARY_PATH

### DIFF
--- a/cerbero/config.py
+++ b/cerbero/config.py
@@ -352,8 +352,7 @@ class Config (object):
         if bindir not in path and self.prefix_is_executable():
             path = self._join_path(bindir, path)
 
-        ld_library_path = self._join_path(
-            os.path.join(self.build_tools_prefix, 'lib'), path)
+        ld_library_path = os.path.join(self.build_tools_prefix, 'lib')
         if self.prefix_is_executable():
             ld_library_path = self._join_path(libdir, ld_library_path)
         if self.extra_lib_path is not None:


### PR DESCRIPTION
Commit 62c77d8e0da15230701c25f016c974beceeda32b added PATH to LD_LIBRARY_PATH when it is unnecessary.

The fact that `PATH` was used for any of the env variables used to calculate the hash used in fridge effectively made that we didn't have 2 machines sharing packages.