### PR TITLE
COM-1107 Improve recipe's checksum to improve consistency

### DIFF
--- a/cerbero/utils/shell.py
+++ b/cerbero/utils/shell.py
@@ -631,33 +631,11 @@ def touch(path, create_if_not_exists=False, offset=0):
     os.utime(path, (t, t))
 
 
-def file_md5(path):
-    '''
-    Get the file md5 hash
-    '''
-    return hashlib.md5(open(path, 'rb').read()).digest()
-
-
 def file_sha256(path):
     '''
     Get the file SHA256 hash
     '''
     return hashlib.sha256(open(path, 'rb').read()).digest()
-
-
-def files_checksum(paths):
-    '''
-    Get the md5 checksum of the files
-
-    @paths: list of paths
-    @type: list
-    @return: the md5 checksum
-    @rtype: str
-    '''
-    m = hashlib.md5()
-    for f in paths:
-        m.update(open(f, 'rb').read())
-    return m.hexdigest()
 
 
 def enter_build_environment(platform, arch, sourcedir=None):


### PR DESCRIPTION
Now a recipes' checksum depends not only on the hash of the
file and its file dependencies, but also on the hash
of the classes that it inherits from.

- Remove the mtime checks since they no longer ensure
  a recipe's status has not changed

- Invalidate the cache for rdeps of a static library if its
  cache has been invalidated. This is the same logic that is
  done in the fetch command

- Add messages to clearly show that a recipe's cache
  has been invalidated