### PR TITLE
Fix issue trying to get source lines of builtin

### DIFF
--- a/cerbero/build/recipe.py
+++ b/cerbero/build/recipe.py
@@ -555,7 +555,7 @@ SOFTWARE LICENSE COMPLIANCE.\n\n'''
         each of those classes
         '''
         sha256 = hashlib.sha256()
-        classes = [c for c in inspect.getmro(self.__class__)[1:] if c.__module__ != 'builtins']
+        classes = [c for c in inspect.getmro(self.__class__) if c.__module__ not in [None, 'builtins']]
         for c in classes:
             sha256.update(self._get_single_class_checksum(c))
         return sha256


### PR DESCRIPTION
Turns out that recipes in fluendo-cerbero have one extra level of indirection, where the top 'Recipe' is in the 'builtins' module while the next 'Recipe' is in None. This fixes the following issue:

```
Traceback (most recent call last):                                                                                                                                                                          
  File "./cerbero-uninstalled", line 14, in <module>                                                                                                                                                        
    main()                                                                                                                                                                                                  
  File "./cerbero/cerbero/main.py", line 195, in main                                                                                                                                                       
    Main(sys.argv[1:])                                                                                                                                                                                      
  File "./cerbero/cerbero/main.py", line 66, in __init__                                                                                                                                                    
    self.run_command()                                                                                                                                                                                      
  File "./cerbero/cerbero/main.py", line 164, in run_command                                                                                                                                                
    res = commands.run(command, self.config, self.args)                                                                                                                                                     
  File "./cerbero/cerbero/commands/__init__.py", line 78, in run                                                                                                                                            
    return _commands[command].run(config, args)                                  
  File "./cerbero/cerbero/commands/fetch.py", line 122, in run
    cookbook = CookBook(config)                                        
  File "./cerbero/cerbero/build/cookbook.py", line 103, in __init__
    self.update()                                                      
  File "./cerbero/cerbero/build/cookbook.py", line 139, in update    
    self._load_recipes()                                    
  File "./cerbero/cerbero/build/cookbook.py", line 439, in _load_recipes
    recipe.run_func_depending_on_built_version(async_tasks, self._reset_recipe_if_needed, recipe)
  File "./cerbero/cerbero/build/recipe.py", line 616, in run_func_depending_on_built_version    
    func(*args)                                                                                            
  File "./cerbero/cerbero/build/cookbook.py", line 409, in _reset_recipe_if_needed
    current_hash = recipe.get_checksum()                                                  
  File "./cerbero/cerbero/build/recipe.py", line 736, in get_checksum
    sha256 = self._get_parents_checksum()                                                                                                          
  File "./cerbero/cerbero/build/recipe.py", line 560, in _get_parents_checksum 
    sha256.update(self._get_single_class_checksum(c))
  File "./cerbero/cerbero/build/recipe.py", line 546, in _get_single_class_checksum                                     
    lines = inspect.getsourcelines(clazz)[0]                           
  File "/usr/lib/python3.6/inspect.py", line 955, in getsourcelines
    lines, lnum = findsource(object)                                  
  File "/usr/lib/python3.6/inspect.py", line 768, in findsource                                 
    file = getsourcefile(object)                                                                        
  File "/usr/lib/python3.6/inspect.py", line 684, in getsourcefile                                                                                     
    filename = getfile(object)                                                    
  File "/usr/lib/python3.6/inspect.py", line 654, in getfile
    raise TypeError('{!r} is a built-in class'.format(object))                                                     
TypeError: None is a built-in class
```