### PR TITLE
COM-1124 Add --home arg globally to override the config one

### DIFF
--- a/cerbero/config.py
+++ b/cerbero/config.py
@@ -158,7 +158,7 @@ class Config (object):
         c._raw_environ = os.environ.copy()
         return c
 
-    def load(self, filename=None, variants_override=None):
+    def load(self, filename=None, variants_override=None, home_dir=None):
         if variants_override is None:
             variants_override = []
 
@@ -175,6 +175,11 @@ class Config (object):
         # Next, if a config file is provided use it to override the settings
         # from the main configuration file
         self._load_cmd_config(filename)
+
+        # After loading the configuration, we set the home_dir if passed
+        # as a parameter to override the configuration value
+        if home_dir:
+            self.home_dir = home_dir
 
         # Create a copy of the config for each architecture in case we are
         # building Universal binaries

--- a/cerbero/main.py
+++ b/cerbero/main.py
@@ -102,6 +102,8 @@ class Main(object):
                 help=_('List available variants'))
         self.parser.add_argument('-v', '--variants', action=VariantAction, default=None,
                 help=_('Variants to be used for the build'))
+        self.parser.add_argument('--home', action='store', type=str, default=None,
+                help=_('Home dir to use. Overrides the one in the configuration'))
         self.parser.add_argument('-c', '--config', action='append', type=str, default=None,
                 help=_('Configuration file used for the build'))
         self.parser.add_argument('-m', '--manifest', action='store', type=str, default=None,
@@ -152,7 +154,7 @@ class Main(object):
             self.config = config.Config()
             if self.args.command == 'shell':
                 self.config.for_shell = True
-            self.config.load(self.args.config, self.args.variants)
+            self.config.load(self.args.config, self.args.variants, home_dir=self.args.home)
             if self.args.manifest:
                 self.config.manifest = self.args.manifest
         except ConfigurationError as exc:


### PR DESCRIPTION
This overrides the home in the config file.

The use case for this is to pass the --home during the CI on non-virtualized machines (e.g. macOS) to work with volatile directories that are disposed after doing the work. This way, instead of reusing the same prefix or doing some other witchcraft, we can simply call:

```
./cerbero-uninstalled -t --home $(mktemp -d) -c [CONFIGURATION_FILE] [COMMAND]
```