### PR TITLE
COM-1158 Decrease possibility of upload contention using fridge

### DIFF
--- a/cerbero/build/fridge.py
+++ b/cerbero/build/fridge.py
@@ -142,8 +142,8 @@ class FtpBinaryRemote (BinaryRemote):
                     pass
 
                 if upload_needed:
-                    shell.ftp_upload(local_filename, remote_filename, ftp_connection=ftp)
                     shell.ftp_upload(local_sha256_filename, remote_filename + '.sha256', ftp_connection=ftp)
+                    shell.ftp_upload(local_filename, remote_filename, ftp_connection=ftp)
                 else:
                     m.action('No need to upload since local and remote SHA256 are the same')
         if ftp:


### PR DESCRIPTION
Upload first the checksum to use it as a lock resource
so that the rest don't upload anything *if the checksum
is the same*. If the checksum changes, both the checksum
and the package will be overwritten. That's ok, though.
As long as the recipe is the same, packages are equally
usable.