### PR TITLE
OPE-875 Remove installed_files before installing the new ones

### DIFF
--- a/cerbero/build/cookbook.py
+++ b/cerbero/build/cookbook.py
@@ -203,22 +203,11 @@ class CookBook (object):
 
         status = self._recipe_status(recipe_name)
         installed_files = set(files)
-        previous_files = set(list(filter(lambda x: _file_exists(self._config.install_dir, x), status.installed_files)))
         existing_files = set(filter(lambda x: _file_exists(self._config.install_dir, x), installed_files))
         non_existing_files = list(installed_files - existing_files)
         if non_existing_files:
-            m.warning('There are some installed files for recipe {} that don\'t exist anymore.'
+            m.warning('There are some installed files for recipe {} that don\'t exist anymore. '
                       'Removing them from recipe\'s cache:\n{}'.format(recipe_name, '\n'.join(non_existing_files)))
-        remove_files = list(previous_files - existing_files)
-        remove_files = [os.path.join(self._config.install_dir, f) for f in remove_files]
-        if remove_files:
-            m.message('Removing old files that existed in previous installation but don\'t exist '
-                      'anymore:\n{}'.format('\n'.join(remove_files)))
-            for f in remove_files:
-                if os.path.islink(f) or not os.path.isdir(f):
-                    os.remove(f)
-                else:
-                    shutil.rmtree(f)
         status.installed_files = list(existing_files)
         self._update_status(recipe_name, status)
         return status.installed_files
@@ -296,8 +285,17 @@ class CookBook (object):
             # old files that may not be present in a new installation
             installed_files = self.status[recipe_name].installed_files
             self.clean_recipe_status(recipe_name)
-            self._recipe_status(recipe_name).installed_files = installed_files
+            if installed_files:
+                self._recipe_status(recipe_name).installed_files = installed_files
             self.save()
+
+    def recipe_remove_installed_files(self, recipe_name):
+        installed_files = self.recipe_installed_files(recipe_name)
+        for f in [os.path.join(self._config.install_dir, f) for f in installed_files]:
+            # os.path.exists returns False for broken symbolic links
+            if os.path.exists(f) or os.path.islink(f):
+                os.remove(f)
+        self._config.cookbook.update_installed_files(recipe_name, [])
 
     def recipe_needs_build(self, recipe_name):
         '''

--- a/cerbero/build/oven.py
+++ b/cerbero/build/oven.py
@@ -219,7 +219,7 @@ class Oven (object):
         # list of installed files for this recipe
         # WARNING: the method to automatically detect files will only work
         # when installing recipes not concurrently
-        if BuildSteps.INSTALL in recipe.steps or BuildSteps.POST_INSTALL in recipe.steps:
+        if set([BuildSteps.INSTALL, BuildSteps.POST_INSTALL]).intersection(set(recipe.steps)):
             self._update_installed_files(recipe, tmp)
 
         if recipe.library_type == LibraryType.STATIC:

--- a/cerbero/build/recipe.py
+++ b/cerbero/build/recipe.py
@@ -127,6 +127,7 @@ class BuildSteps(object):
 
     FETCH = (N_('Fetch'), 'fetch')
     EXTRACT = (N_('Extract'), 'extract')
+    CLEAN_INSTALLED_FILES = (N_('Clean installed files'), 'clean_installed_files')
     CONFIGURE = (N_('Configure'), 'configure')
     COMPILE = (N_('Compile'), 'compile')
     INSTALL = (N_('Install'), 'install')
@@ -140,7 +141,7 @@ class BuildSteps(object):
     DELETE_RPATH = (N_('Delete rpath from binaries'), 'delete_rpath')
 
     def __new__(cls):
-        return [BuildSteps.FETCH, BuildSteps.EXTRACT,
+        return [BuildSteps.FETCH, BuildSteps.EXTRACT, BuildSteps.CLEAN_INSTALLED_FILES,
                 BuildSteps.CONFIGURE, BuildSteps.COMPILE, BuildSteps.INSTALL,
                 BuildSteps.POST_INSTALL]
 
@@ -583,6 +584,12 @@ SOFTWARE LICENSE COMPLIANCE.\n\n'''
             self._write_license_readme(licenses_files, install_dir, 'binaries')
         elif self.licenses_bins is not None:
             raise AssertionError('{}.recipe: unknown licenses_bins type'.format(self.name))
+
+    def clean_installed_files(self):
+        '''
+        Runs the clean_installed_files step
+        '''
+        self.config.cookbook.recipe_remove_installed_files(self.name)
 
     def post_install(self):
         '''

--- a/cerbero/commands/uninstall.py
+++ b/cerbero/commands/uninstall.py
@@ -69,12 +69,7 @@ class Uninstall(Command):
             # As a fallback, in case the uninstall target does not exist,
             # or in case it misses some of the installed files, remove
             # them manually
-            installed_files = cookbook.recipe_installed_files(recipe_name)
-            for f in [os.path.join(config.install_dir, f) for f in installed_files]:
-                # os.path.exists returns False for broken symbolic links
-                if os.path.exists(f) or os.path.islink(f):
-                    os.remove(f)
-
+            cookbook.recipe_remove_installed_files(recipe_name)
             cookbook.clean_recipe_status(recipe_name)
 
             # Lastly, remove the build directory
@@ -82,7 +77,6 @@ class Uninstall(Command):
             if os.path.isdir(build_dir):
                 shutil.rmtree(build_dir)
 
-        shell.remove_empty_dirs(config.install_dir)
         m.message('Recipes uninstalled: {}'.format(' '.join(recipe_names)))
 
 

--- a/cerbero/utils/shell.py
+++ b/cerbero/utils/shell.py
@@ -782,12 +782,3 @@ def run_until_complete(tasks, max_concurrent=16):
     else:
         result = loop.run_until_complete(tasks)
     return result
-
-
-def remove_empty_dirs(path):
-    '''
-    Remove all empty dirs within path
-    @param path: the path to remove empty dirs from
-    @type path: str
-    '''
-    new_call('find {} -type d -empty -delete'.format(path))


### PR DESCRIPTION
Previous logic didn't work properly when the files were never actually copied because they were the same.

New step is added: `clean_old` which doesn't run the uninstall step which may be quite slow on some machines (e.g. Windows), but ensures the previous list of installed files is manually removed prior to the install step.