### PR TITLE
OPE-884 Fix dylib's not relocated using fridge in macOS

### DIFF
--- a/cerbero/build/relocatabletar.py
+++ b/cerbero/build/relocatabletar.py
@@ -18,9 +18,12 @@ class RelocatableTar(TarFile):
             if self._is_relocatable(full_member_path):
                 self._relocate(full_member_path, extract_to_path)
 
+    def _has_relocatable_content(self, file):
+        return False
+
     def _is_relocatable(self, file):
         if not os.path.islink(file) and not os.path.isdir(file):
-            return is_text_file(file)
+            return self._has_relocatable_content(file) or is_text_file(file)
         else:
             return False
 
@@ -39,17 +42,13 @@ class RelocatableTarOSX(RelocatableTar):
 
     def extract_and_relocate(self, extract_to_path):
         self.relocator = OSXRelocator(extract_to_path, extract_to_path, True)
-        RelocatableTar.extract_and_relocate(self, extract_to_path)
+        super().extract_and_relocate(extract_to_path)
 
-    def _is_dylib_file(self, file):
-        return os.path.splitext(file)[1] in ['.dylib']
-
-    def _has_relocatable_extension(self, file):
-        return (RelocatableTar._has_relocatable_extension(self, file) or
-                self._is_dylib_file(file))
+    def _has_relocatable_content(self, file):
+        return self.relocator.is_mach_o_file(file) or super()._has_relocatable_content(file)
 
     def _relocate(self, file, subst_path):
-        if self._is_dylib_file(file):
+        if self.relocator.is_mach_o_file(file):
             self.relocator.change_id(file, file)
         else:
-            RelocatableTar._relocate(self, file, subst_path)
+            super()._relocate(file, subst_path)

--- a/cerbero/tools/osxrelocator.py
+++ b/cerbero/tools/osxrelocator.py
@@ -55,7 +55,7 @@ class OSXRelocator(object):
     def change_id(self, object_file, id=None):
         id = id or object_file.replace(self.lib_prefix, '@rpath')
         filename = os.path.basename(object_file)
-        if not (filename.endswith('so') or filename.endswith('dylib')):
+        if not self.is_mach_o_file(filename):
             return
         cmd = '%s -id "%s" "%s"' % (INT_CMD, id, object_file)
         shell.call(cmd, fail=False, logfile=self.logfile)
@@ -97,6 +97,10 @@ class OSXRelocator(object):
                 self.change_libs_path(os.path.join(dirpath, f))
             if not self.recursive:
                 break
+
+    def is_mach_o_file(self, filename):
+        return '.dylib' in os.path.splitext(filename)[1] or \
+                shell.check_output('file', '-bh', '\"' + filename + '\"').startswith('Mach-O')
 
     @staticmethod
     def list_shared_libraries(object_file):


### PR DESCRIPTION
This comes from an error backporting fridge from master to 1.0. This is the original code: https://github.com/fluendo/cerbero/blob/master/cerbero/build/relocatabletar.py#L17-L39

I fixed the relocations of text files (some of them which are not considered ASCII text by the `file` command but still require to be relocated. e.g. autotools scripts) but didn't include the code to properly relocate dylib's :facepalm: