### PR TITLE
OPE-889 Fix libkate compilation in newer gcc versions

### DIFF
--- a/recipes/libkate.recipe
+++ b/recipes/libkate.recipe
@@ -9,7 +9,8 @@ class Recipe(recipe.Recipe):
     tarball_checksum = 'c40e81d5866c3d4bf744e76ce0068d8f388f0e25f7e258ce0c8e76d7adc87b68'
     licenses = [{License.BSD_like: ['COPYING']}]
     deps = ['libogg', 'libpng']
-    patches = ['libkate/0001-be-more-permissive-with-automake-errors-now-that-we-.patch']
+    patches = ['libkate/0001-be-more-permissive-with-automake-errors-now-that-we-.patch',
+               'libkate/0001-Remove-unnecessary-link-against-liblex-for-kateenc.patch']
 
     files_libs = ['libkate', 'liboggkate']
     files_devel = ['include/kate', 'lib/pkgconfig/kate.pc', 'lib/pkgconfig/oggkate.pc']

--- a/recipes/libkate/0001-Remove-unnecessary-link-against-liblex-for-kateenc.patch
+++ b/recipes/libkate/0001-Remove-unnecessary-link-against-liblex-for-kateenc.patch
@@ -1,0 +1,25 @@
+From cdeecec7bc7b83a235203aef3b78157e52118eb2 Mon Sep 17 00:00:00 2001
+From: Pablo Marcos Oltra <pablo.marcos.oltra@gmail.com>
+Date: Mon, 20 Apr 2020 19:01:11 +0200
+Subject: [PATCH] Remove unnecessary link against liblex for kateenc
+
+---
+ tools/Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/Makefile.am b/tools/Makefile.am
+index 2be12a3..48076a1 100644
+--- a/tools/Makefile.am
++++ b/tools/Makefile.am
+@@ -20,7 +20,7 @@ kateenc_SOURCES+=kpng.c
+ endif
+ katedec_SOURCES=katedec.c kkate.c ksrt.c klrc.c kutil.c kfuzz.c kstream.c kread.c kstrings.c
+ katalyzer_SOURCES=katalyzer.c kutil.c kstream.c kread.c kstrings.c kstats.c
+-kateenc_LDADD=../lib/liboggkate.la ../lib/libkate.la @OGG_LIBS@ @PNG_LIBS@ @LEXLIB@
++kateenc_LDADD=../lib/liboggkate.la ../lib/libkate.la @OGG_LIBS@ @PNG_LIBS@
+ katedec_LDADD=../lib/liboggkate.la ../lib/libkate.la @OGG_LIBS@
+ katalyzer_LDADD=../lib/liboggkate.la ../lib/libkate.la @OGG_LIBS@
+ kateenc_CFLAGS=@CWARNFLAGS_LIGHT@ @CFLAGS_FORTIFY_SOURCE@ @CFLAGS_DEBUG@ @OGG_CFLAGS@ @PNG_CFLAGS@
+-- 
+2.17.1
+


### PR DESCRIPTION
kateenc links unnecessarily against flex, while flex has an undefined symbol needed that cannot be resolved at link time: yylex.