### PR TITLE
HS-3667 Add CERBERO_TOOLCHAIN_PREFIX relocation

### DIFF
--- a/cerbero/build/fridge.py
+++ b/cerbero/build/fridge.py
@@ -237,7 +237,7 @@ class Fridge (object):
                     tarclass = RelocatableTar
                 tar = tarclass.open(os.path.join(self.binaries_local,
                                                  filename), 'r:bz2')
-                tar.extract_and_relocate(self.config.install_dir)
+                tar.extract_and_relocate(self.config.prefix, self.config.toolchain_prefix)
                 tar.close()
 
     def generate_binary(self, recipe):

--- a/cerbero/packages/disttarball.py
+++ b/cerbero/packages/disttarball.py
@@ -178,7 +178,15 @@ class DistTarball(PackagerBase):
                     restore_files.append(filepath)
                     with open(filepath, 'rb+') as fo:
                         content = fo.read()
-                        content = replace_prefix_in_bytes(self.config.prefix, content, 'CERBERO_PREFIX')
+                        # Relocate first the longest of the paths
+                        if self.config.toolchain_prefix and self.config.toolchain_prefix in self.config.prefix:
+                            content = replace_prefix_in_bytes(self.config.prefix, content, 'CERBERO_PREFIX')
+                            if self.config.toolchain_prefix:
+                                content = replace_prefix_in_bytes(self.config.toolchain_prefix, content, 'CERBERO_TOOLCHAIN_PREFIX')
+                        else:
+                            if self.config.toolchain_prefix:
+                                content = replace_prefix_in_bytes(self.config.toolchain_prefix, content, 'CERBERO_TOOLCHAIN_PREFIX')
+                            content = replace_prefix_in_bytes(self.config.prefix, content, 'CERBERO_PREFIX')
                         fo.seek(0)
                         fo.write(content)
                         fo.truncate()


### PR DESCRIPTION
Some files may have paths that are outside of the prefix. e.g. gnustl.pc contains config.toolchain_prefix path, which on Android is outisde of config.prefix. Without changing this, it's not possible to relocate the packages.
