### PR TITLE
Fix missing files on fridge packages generated by Windows native

### DIFF
--- a/cerbero/build/oven.py
+++ b/cerbero/build/oven.py
@@ -168,7 +168,7 @@ class Oven (object):
         # Windows and macOS have a 1 sec while Linux has millisecond. Hence, we
         # sleep enough to make sure the files from previous recipes are not
         # taken
-        if count != 1 and self.config.platform != Platform.LINUX:
+        if self.config.platform != Platform.LINUX:
             time.sleep(1.5)
 
         if use_binaries:


### PR DESCRIPTION
There may be the case in which we only build one recipe which is very fast building (e.g. openh264) that may cause trouble.