### PR TITLE
Override FilesProvider py_prefix on Windows

### DIFF
--- a/cerbero/build/filesprovider.py
+++ b/cerbero/build/filesprovider.py
@@ -24,6 +24,7 @@ import inspect
 from functools import partial
 import shlex
 from pathlib import Path
+import sysconfig
 
 from cerbero.config import Platform, LibraryType
 from cerbero.utils import shell
@@ -154,7 +155,13 @@ class FilesProvider(object):
         self.extensions = self.EXTENSIONS[self.platform].copy()
         if self._dylib_plugins():
             self.extensions['mext'] = '.dylib'
-        self.py_prefix = config.py_prefix
+        if config.platform == Platform.WINDOWS:
+            # On Windows, py_prefix doesn't include Python version although some
+            # packages (pycairo, gi, etc...) install themselves using Python
+            # version scheme like on a posix system.
+            self.py_prefix = sysconfig.get_path('stdlib', 'posix_prefix', vars={'installed_base': ''})[1:]
+        else:
+            self.py_prefix = config.py_prefix
         self.add_files_bins_devel()
         self.add_license_files()
         self.categories = self._files_categories()
@@ -416,7 +423,7 @@ class FilesProvider(object):
         if os.path.exists(os.path.join(self.config.prefix, f)):
             return f
         else:
-            pydir = os.path.basename(os.path.normpath(self.config.py_prefix))
+            pydir = os.path.basename(os.path.normpath(self.py_prefix))
             pyversioname = re.sub("python|\.", '', pydir)
             cpythonname = "cpython-" + pyversioname
 


### PR DESCRIPTION
On Windows py_prefix is detected as 'Lib' whereas recipes still install
their python files in the posix prefix: 'lib/python[version]'. So we
override the py_prefix in FilesProvider on Windows in order to fetch
python files from the right place.