### PR TITLE
[OPE-909] Fix GnuTLS issue by forcing git commands to use system's libs

### DIFF
--- a/cerbero/build/source.py
+++ b/cerbero/build/source.py
@@ -339,7 +339,7 @@ class GitCache (Source):
         if not self.cached_built_version:
             git_hash = 'error_getting_hash'
             try:
-                git_hash = await git.async_get_hash(self.repo_dir, self.commit, self.remotes)
+                git_hash = await git.async_get_hash(self.config, self.repo_dir, self.commit, self.remotes)
             finally:
                 self.cached_built_version = '%s+git~%s' % (self.version, git_hash)
         return self.cached_built_version
@@ -414,8 +414,8 @@ class Git (GitCache):
     def extract(self):
         if os.path.exists(self.build_dir):
             try:
-                commit_hash = git.get_hash(self.repo_dir, self.commit)
-                checkout_hash = git.get_hash(self.build_dir, 'HEAD')
+                commit_hash = git.get_hash(self.config, self.repo_dir, self.commit)
+                checkout_hash = git.get_hash(self.config, self.build_dir, 'HEAD')
                 if commit_hash == checkout_hash and not self.patches:
                     return False
             except Exception:

--- a/cerbero/commands/fetch.py
+++ b/cerbero/commands/fetch.py
@@ -245,7 +245,7 @@ class FetchCache(Command):
                         "cerbero-uninstalled"))
 
         git_dir = os.path.dirname(sys.argv[0])
-        sha = git.get_hash(git_dir, args.commit)
+        sha = git.get_hash(config, git_dir, args.commit)
         deps = self.get_deps(config, args)
         if not args.skip_fetch:
             dep = self.find_dep(deps, sha)

--- a/cerbero/utils/__init__.py
+++ b/cerbero/utils/__init__.py
@@ -209,7 +209,10 @@ Terminating.''', file=sys.stderr)
                         d = (name, version, '');
         if d[0] in ['Ubuntu', 'debian', 'LinuxMint']:
             distro = Distro.DEBIAN
-            distro_version = d[2].split()[0].lower()
+            distro_version = d[2].lower()
+            split_str = d[2].split()
+            if split_str:
+                distro_version = split_str[0].lower()
             if distro_version in ['maverick', 'isadora']:
                 distro_version = DistroVersion.UBUNTU_MAVERICK
             elif distro_version in ['lucid', 'julia']:


### PR DESCRIPTION
This workaround only works for the git calls that are done outside the fetch step. Within the fetch step, the right environment is already set, so there's no issue there. Outside of fetch steps, the prefix libraries are used before the system ones. The issue happens because git is taking the GnuTLS from the prefix. This is an older version that doesn't support what a new git supports and hence the trouble.