### PR TITLE
Allow parallel builds on Windows

### DIFF
--- a/config/windows.config
+++ b/config/windows.config
@@ -109,7 +109,7 @@ if platform == Platform.WINDOWS:
     # either hang or print server errors like:
     # 2068442963 [sig] make 18324 sig_dispatch_pending: Win32 error 298 releasing sigcatch_nosync(0x150)
     # Only use one process to make the build more reliable.
-    allow_parallel_build = False
+    #allow_parallel_build = False
 
     os.environ['ACLOCAL'] = 'aclocal-1.11'
 


### PR DESCRIPTION
Even if we set in default cerbero.cbc config something different,
since the default OS config is parsed afterwards, it overrides
the configuration value.