### PR TITLE
OCP-1699 Fix recipes not reset if checksum changes when half-built

### DIFF
--- a/cerbero/build/cookbook.py
+++ b/cerbero/build/cookbook.py
@@ -19,7 +19,6 @@
 from collections import defaultdict
 import os
 import pickle
-import time
 import imp
 import traceback
 import shutil
@@ -414,7 +413,7 @@ class CookBook (object):
             return True
 
         st = self.status[recipe_name]
-        return not st.built_version and st.needs_build
+        return not st.steps
 
     def _reset_recipe_status(self, recipe, change_name, previous, now):
         if self._recipe_is_reset(recipe.name):


### PR DESCRIPTION
We need to ensure the steps list is empty, rather than
relying on built_version and needs_build being on their
default value, since when recipes are half-built they are
still in their default value but may still need to be reset.