### PR TITLE
Fix performance issue collectig the built_version

### DIFF
--- a/cerbero/build/cookbook.py
+++ b/cerbero/build/cookbook.py
@@ -442,15 +442,17 @@ class CookBook (object):
         # inherited from a different file, f.ex. recipes/custom.py
         # This only needs to be done when the checksum does not depend
         # on the parents, hence when strict_recipe_checksum is not used
-        bv = recipe.built_version()
-        if bv != st.built_version and not self._config.strict_recipe_checksum:
-            self._reset_recipe_status(recipe, 'built_version', st.built_version, bv)
-        else:
-            # Use getattr as file_hash we added later
-            saved_hash = getattr(st, 'file_hash', '')
-            current_hash = recipe.get_checksum()
-            if saved_hash != current_hash:
-                self._reset_recipe_status(recipe, 'file_hash', saved_hash, current_hash)
+        if not self._config.strict_recipe_checksum:
+            bv = recipe.built_version()
+            if bv != st.built_version:
+                self._reset_recipe_status(recipe, 'built_version', st.built_version, bv)
+                return
+
+        # Use getattr as file_hash we added later
+        saved_hash = getattr(st, 'file_hash', '')
+        current_hash = recipe.get_checksum()
+        if saved_hash != current_hash:
+            self._reset_recipe_status(recipe, 'file_hash', saved_hash, current_hash)
 
     def _load_recipes(self):
         self.recipes = {}


### PR DESCRIPTION
In short, if we're using the strict recipe checksum (which we are, on the CI), there's no need to check if the built_version changed because of any of the parents. Collecting the built_version for a recipe which source is Git and where it's downloaded using fridge, involves calling `git ls-remote` to collect the hash of the commit, since there is no local repo available.

This is a proper fix for the same issue that commit 413f327a4af53d6e005d89f41c062e614bbbdcc5 attempted to fix.
However, it did not really bypass the built_version collection. This one does.