### PR TITLE
Add --fridge to act as if --use-binaries has been passed

### DIFF
--- a/cerbero/commands/bootstrap.py
+++ b/cerbero/commands/bootstrap.py
@@ -82,7 +82,7 @@ class FetchBootstrap(Command):
         args = [
             ArgparseArgument('--build-tools-only', action='store_true',
                 default=False, help=_('only fetch the build tools')),
-            ArgparseArgument('--use-binaries', action='store_true',
+            ArgparseArgument('--use-binaries', '--fridge', action='store_true',
                 default=False, help=_('use binaries from the repo before building')),
             ArgparseArgument('--jobs', '-j', action='store', nargs='?', type=int,
                     const=NUMBER_OF_JOBS_IF_USED, default=NUMBER_OF_JOBS_IF_UNUSED, help=_('number of async jobs'))]

--- a/cerbero/commands/fetch.py
+++ b/cerbero/commands/fetch.py
@@ -46,7 +46,7 @@ class Fetch(Command):
                     default=False, help=_('print all source URLs to stdout')))
         args.append(ArgparseArgument('--full-reset', action='store_true',
                     default=False, help=_('reset to extract step if rebuild is needed')))
-        args.append(ArgparseArgument('--use-binaries', action='store_true',
+        args.append(ArgparseArgument('--use-binaries', '--fridge', action='store_true',
                     default=False, help=_('use fridge to download binary packages if available')))
         args.append(ArgparseArgument('--jobs', '-j', action='store', nargs='?', type=int,
                     const=NUMBER_OF_JOBS_IF_USED, default=NUMBER_OF_JOBS_IF_UNUSED, help=_('number of async jobs')))


### PR DESCRIPTION
This is done for compatibility reasons, because it simplifies
our CI logic so that we can pass exactly the same argument
to all of the commands.