### PR TITLE
Remove also local sources when uninstalling

### DIFF
--- a/cerbero/commands/uninstall.py
+++ b/cerbero/commands/uninstall.py
@@ -72,12 +72,16 @@ class Uninstall(Command):
             recipe.clean_installed_files()
             cookbook.clean_recipe_status(recipe_name)
 
-            # Lastly, remove the build directory
-            build_dir = os.path.join(config.sources, recipe.package_name)
-            if os.path.isdir(build_dir):
-                shutil.rmtree(build_dir)
+            # Lastly, remove the build and local sources directory
+            self._remove_sources_dir(os.path.join(config.sources, recipe.package_name))
+            self._remove_sources_dir(os.path.join(config.local_sources, recipe.package_name))
 
         m.message('Recipes uninstalled: {}'.format(' '.join(recipe_names)))
+
+    def _remove_sources_dir(self, dir):
+        if os.path.isdir(dir):
+            m.message('Removing sources directory {}'.format(dir))
+            shutil.rmtree(dir)
 
 
 register_command(Uninstall)


### PR DESCRIPTION
Initially, I left on purpose the local sources untouched so that we don't need to re-fetch from start. However, the typical use case for this is to remove everything related to a recipe so that we don't need to explicitly fetch before building again. Thus if zlib recipe changes and we want to get rid of previous files:

```
time ./cerbero-uninstalled -t -c projects/codecs/1.0/cross-win64.cbc uninstall zlib
time ./cerbero-uninstalled -t -c projects/codecs/1.0/cross-win64.cbc fetch zlib
time ./cerbero-uninstalled -t -c projects/codecs/1.0/cross-win64.cbc buildone zlib
```
can be simply done by
```
time ./cerbero-uninstalled -t -c projects/codecs/1.0/cross-win64.cbc uninstall zlib
time ./cerbero-uninstalled -t -c projects/codecs/1.0/cross-win64.cbc buildone zlib
```