### PR TITLE
OCP-1781 Add checksum of deps to make it safer

### DIFF
--- a/cerbero/build/fridge.py
+++ b/cerbero/build/fridge.py
@@ -229,7 +229,9 @@ class Fridge (object):
 
     async def fetch_binary(self, recipe):
         self._ensure_ready(recipe)
-        await self.binaries_remote.fetch_binary(self._get_package_names(recipe).values(),
+        package_names = self._get_package_names(recipe).values()
+        m.action('Downloading fridge package {}/{}'.format(self.env_checksum, list(package_names)[0]))
+        await self.binaries_remote.fetch_binary(package_names,
                                           self.binaries_local, self.env_checksum)
 
     def extract_binary(self, recipe):
@@ -304,7 +306,7 @@ class Fridge (object):
 
     async def _apply_steps(self, recipe, steps, build_status_printer, count):
         self._ensure_ready(recipe)
-        for desc, step in steps:
+        for _, step in steps:
             build_status_printer.update_recipe_step(count, recipe.name, step)
             # check if the current step needs to be done
             if self.cookbook.step_done(recipe.name, step) and not self.force:

--- a/cerbero/build/recipe.py
+++ b/cerbero/build/recipe.py
@@ -556,6 +556,19 @@ SOFTWARE LICENSE COMPLIANCE.\n\n'''
             sha256.update(get_class_checksum(c))
         return sha256
 
+    def _get_deps_checksum(self, sha256):
+        '''
+        Add to the given SHA256 the checksum of its dependencies in case
+        they are static
+        '''
+        if not self.config.strict_recipe_checksum:
+            return sha256
+        deps = self.list_deps()
+        for dep in deps:
+            recipe = self.config.cookbook.get_recipe(dep)
+            sha256.update(recipe.get_checksum().encode('utf-8'))
+        return sha256
+
     def install_licenses(self):
         '''
         NOTE: This list of licenses is only indicative and is not guaranteed to
@@ -737,6 +750,7 @@ SOFTWARE LICENSE COMPLIANCE.\n\n'''
         @rtype: str
         '''
         sha256 = self._get_parents_checksum()
+        sha256 = self._get_deps_checksum(sha256)
         for f in self._get_files_dependencies():
             sha256.update(open(f, 'rb').read())
         return sha256.hexdigest()


### PR DESCRIPTION
Add checksum of deps to make it safer

Even though sometimes the recipe can be the same,
the resulting artifact can be different. An example
is when the configure for a given recipe does something
different in case of different versions of its dependencies.
e.g. flu-codec-sdk and the files it includes depends
on the version of glib.

This way, we make the checksum more robust.

Before
```
./cerbero-uninstalled -t -c projects/codecs/0.10/native.cbc buildone flu-codec-sdk --use-binaries
...
0:00:01.252552 WARNING: Package 'ftp://officestorage1.fluendo.lan/data/fluendo/tech/public/cerbero-binaries-1.0/f8d40391/flu-codec-sdk-linux-x86_64-1.0+git~5049634c-0f6adcfe-devel.tar.bz2' not found

./cerbero-uninstalled -t -c projects/codecs/0.10-glib-2.58/native.cbc buildone flu-codec-sdk --use-binaries
...
0:00:01.266555 WARNING: Package 'ftp://officestorage1.fluendo.lan/data/fluendo/tech/public/cerbero-binaries-1.0/f8d40391/flu-codec-sdk-linux-x86_64-1.0+git~5049634c-0f6adcfe-devel.tar.bz2' not found
```

After
```
./cerbero-uninstalled -t -c projects/codecs/0.10/native.cbc buildone flu-codec-sdk --use-binaries
...
0:00:01.430895 WARNING: Package 'ftp://officestorage1.fluendo.lan/data/fluendo/tech/public/cerbero-binaries-1.0/f8d40391/flu-codec-sdk-linux-x86_64-1.0+git~5049634c-fa705dd0-devel.tar.bz2' not found

./cerbero-uninstalled -t -c projects/codecs/0.10-glib-2.58/native.cbc buildone flu-codec-sdk --use-binaries
...
0:00:01.304787 WARNING: Package 'ftp://officestorage1.fluendo.lan/data/fluendo/tech/public/cerbero-binaries-1.0/f8d40391/flu-codec-sdk-linux-x86_64-1.0+git~5049634c-2a8f25ae-devel.tar.bz2' not found
```

Take into account that this implies a rebuild of every single recipe because it changes the checksum of all of them.