### PR TITLE
Pass -v/--verbose to show filepaths in list commands

### DIFF
--- a/cerbero/commands/list.py
+++ b/cerbero/commands/list.py
@@ -16,20 +16,20 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-from cerbero.config import Variants
 from cerbero.commands import Command, register_command
 from cerbero.build.cookbook import CookBook
 from cerbero.utils import _, N_
 from cerbero.utils import messages as m
 from cerbero.packages.packagesstore import PackagesStore
-
+from cerbero.utils import ArgparseArgument
 
 class List(Command):
     doc = N_('List all the available recipes')
     name = 'list'
 
     def __init__(self):
-        Command.__init__(self, [])
+        Command.__init__(self, [ArgparseArgument('-v', '--verbose', action='store_true', default=False,
+                                help=_('be verbose, showing the filepaths'))])
 
     def run(self, config, args):
         cookbook = CookBook(config)
@@ -42,7 +42,8 @@ class List(Command):
             except:
                 current = "Not checked out"
 
-            m.message("%s - %s (current checkout: %s)" % (recipe.name, recipe.version, current))
+            filepath_str = "- " + recipe.__file__  if args.verbose else ""
+            m.message("%s - %s (current checkout: %s) %s" % (recipe.name, recipe.version, current, filepath_str))
 
 
 class ListPackages(Command):
@@ -50,15 +51,16 @@ class ListPackages(Command):
     name = 'list-packages'
 
     def __init__(self):
-        Command.__init__(self, [])
-
+        Command.__init__(self, [ArgparseArgument('-v', '--verbose', action='store_true', default=False,
+                                help=_('be verbose, showing the filepaths'))])
     def run(self, config, args):
         store = PackagesStore(config)
         packages = store.get_packages_list()
         if len(packages) == 0:
             m.message(_("No packages found"))
         for p in packages:
-            m.message("%s - %s" % (p.name, p.version))
+            filepath_str = "- " + p.__file__  if args.verbose else ""
+            m.message("%s - %s %s" % (p.name, p.version, filepath_str))
 
 class ShowConfig(Command):
     doc = N_('Show configuration settings')


### PR DESCRIPTION
```
./cerbero-uninstalled -t -c projects/codecs/1.0/native.cbc list -v
0:00:00.001785 Loading default configuration from /home/pablo/.cerbero/cerbero.cbc
0:00:00.899345 a52dec - 0.7.4 (current checkout: ) - /home/pablo/Fluendo/fluendo-cerbero/cerbero/recipes/a52dec.recipe
0:00:00.899583 autoconf - 2.69 (current checkout: ) - /home/pablo/Fluendo/fluendo-cerbero/cerbero/recipes/build-tools/autoconf.recipe
0:00:00.899712 automake - 1.15.1 (current checkout: ) - /home/pablo/Fluendo/fluendo-cerbero/cerbero/recipes/build-tools/automake.recipe
0:00:00.899790 bison - 3.6.4 (current checkout: ) - /home/pablo/Fluendo/fluendo-cerbero/cerbero/recipes/build-tools/bison.recipe
...
```

```
./cerbero-uninstalled -t -c projects/codecs/1.0/native.cbc list-packages -v
0:00:00.002336 Loading default configuration from /home/pablo/.cerbero/cerbero.cbc
0:00:01.038643 base-crypto - 1.15.90.1 - /home/pablo/Fluendo/fluendo-cerbero/cerbero/packages/base-crypto.package
0:00:01.038693 base-system-1.0 - 1.15.90.1 - /home/pablo/Fluendo/fluendo-cerbero/cerbero/packages/base-system-1.0.package
0:00:01.038711 fluendo-dvd-development - 2012.7 - /home/pablo/Fluendo/fluendo-cerbero/packages/fluendo-dvd-development.package
0:00:01.038730 fluendo-dvd-development-installer - 2012.7 - /home/pablo/Fluendo/fluendo-cerbero/packages/fluendo-dvd-development-installer.package
0:00:01.038746 fluvas-deps - 1.0 - /home/pablo/Fluendo/fluendo-cerbero/packages/vas/fluvas-deps.package
```