### PR TITLE
Fix Ftp class for not working with the proper remote_url

### DIFF
--- a/cerbero/build/fridge.py
+++ b/cerbero/build/fridge.py
@@ -34,7 +34,6 @@ from cerbero.utils import N_, _, shell, run_until_complete
 from cerbero.utils.shell import Ftp
 from cerbero.utils import messages as m
 from cerbero.packages.disttarball import DistTarball
-from cerbero.enums import ArchiveType
 from cerbero.packages import PackageType
 
 

--- a/cerbero/utils/shell.py
+++ b/cerbero/utils/shell.py
@@ -494,24 +494,25 @@ async def download(url, destination=None, check_cert=True, overwrite=False, logf
 
 class Ftp:
     def __init__(self, remote_url, user=None, password=None):
-        self.remote = urllib.parse.urlparse(remote_url)
+        remote = urllib.parse.urlparse(remote_url)
         self.ftp = FTP()
-        self.ftp.connect(self.remote.hostname, self.remote.port or 0)
+        self.ftp.connect(remote.hostname, remote.port or 0)
         self.ftp.login(user, password)
 
     def close(self):
         self.ftp.quit()
 
     def file_exists(self, remote_url):
+        remote = urllib.parse.urlparse(remote_url)
         try:
-            self.ftp.cwd(os.path.dirname(self.remote.path))
+            self.ftp.cwd(os.path.dirname(remote.path))
             files = self.ftp.nlst()
-            exists = os.path.basename(self.remote.path) in files
-            return exists
+            return os.path.basename(remote.path) in files
         except Exception:
             return False
 
     def download(self, remote_url, local_filename):
+        remote = urllib.parse.urlparse(remote_url)
         self.ftp.cwd(os.path.dirname(remote.path))
         with open(local_filename, 'wb') as f:
             self.ftp.retrbinary('RETR ' + os.path.basename(remote.path), f.write)


### PR DESCRIPTION
This is a clear and easy to fix mistake. My guess is that happened during a refactoring of self.remote, but it the code as it was doesn't make any sense. We have not seen any issue with the download method because we're using aftp for that. The upload method is ok, but file_exists and download are completely wrong:

Before. It uploads ENVIRONMENT file no matter it exists already or not because file_exists is broken:

```
tree ~/Fluendo/fridge && ./cerbero-uninstalled -c projects/codecs/1.0/native.cbc edit-cache libffi --steps 'install', 'extract', 'clean_installed_files', 'generate_binary', 'configure', 'post_install', 'delete_rpath', 'compile', 'fetch' && ./cerbero-uninstalled -c projects/codecs/1.0/native.cbc build libffi --upload-binaries && tree ~/Fluendo/fridge
/home/pablo/Fluendo/fridge
└── 85461631
    ├── ENVIRONMENT
    ├── libffi-linux-x86_64-3.2.9999+git~369ef49f-5c6852d4-devel.tar.bz2
    └── libffi-linux-x86_64-3.2.9999+git~369ef49f-5c6852d4-devel.tar.bz2.sha256

1 directory, 3 files
Loading default configuration from /home/pablo/.cerbero/cerbero.cbc
WARNING: git remote origin URL 'ssh://git@github.com/libffi/libffi.git' uses 'ssh', please only use this for testing
Modifying cache values for recipes: libffi
[libffi]
Before
steps: ['generate_binary,', 'upload_binary', 'post_install,', 'compile,', 'generate_binary', 'install,', 'extract,', 'fetch', 'clean_installed_files,', 'configure,', 'delete_rpath,'], needs_build: False, filepath: '/home/pablo/Fluendo/fluendo-cerbero/cerbero/recipes/libffi.recipe', built_version: '3.2.9999+git~369ef49f', file_hash: '5c6852d427fdc3789412e4e16a9746b9ecaff3fcffadf88be8530907e8facfca'
installed_files: ['share/man/man3/ffi_prep_cif_var.3', 'lib/libffi.a', 'lib/pkgconfig/libffi.pc', 'include/ffitarget-x86_64.h', 'share/man/man3/ffi_prep_cif.3', 'share/man/man3/ffi.3', 'share/licenses/libffi/LICENSE', 'share/man/man3/ffi_call.3', 'lib/libffi.so.7.1.0', 'include/ffi.h', 'include/ffitarget.h', 'lib/libffi.so.7', 'lib/libffi.la', 'include/ffi-x86_64.h', 'share/licenses/libffi/README-LICENSE-INFO.txt', 'lib/libffi.so']

After
steps: ['install,', 'extract,', 'clean_installed_files,', 'generate_binary,', 'configure,', 'post_install,', 'delete_rpath,', 'compile,', 'fetch'], needs_build: False, filepath: '/home/pablo/Fluendo/fluendo-cerbero/cerbero/recipes/libffi.recipe', built_version: '3.2.9999+git~369ef49f', file_hash: '5c6852d427fdc3789412e4e16a9746b9ecaff3fcffadf88be8530907e8facfca'
installed_files: ['share/man/man3/ffi_prep_cif_var.3', 'lib/libffi.a', 'lib/pkgconfig/libffi.pc', 'include/ffitarget-x86_64.h', 'share/man/man3/ffi_prep_cif.3', 'share/man/man3/ffi.3', 'share/licenses/libffi/LICENSE', 'share/man/man3/ffi_call.3', 'lib/libffi.so.7.1.0', 'include/ffi.h', 'include/ffitarget.h', 'lib/libffi.so.7', 'lib/libffi.la', 'include/ffi-x86_64.h', 'share/licenses/libffi/README-LICENSE-INFO.txt', 'lib/libffi.so']

Loading default configuration from /home/pablo/.cerbero/cerbero.cbc
WARNING: git remote origin URL 'ssh://git@github.com/libffi/libffi.git' uses 'ssh', please only use this for testing
Building the following recipes: libffi
Fridge initialized with environment hash 85461631
[(1/1 @ 0%) libffi -> generate_binary]
[(1/1 @ 0%) libffi -> upload_binary]
Uploading environment file to ftp://localhost:2121/85461631/ENVIRONMENT
/home/pablo/Fluendo/fridge
└── 85461631
    ├── ENVIRONMENT
    ├── libffi-linux-x86_64-3.2.9999+git~369ef49f-5c6852d4-devel.tar.bz2
    └── libffi-linux-x86_64-3.2.9999+git~369ef49f-5c6852d4-devel.tar.bz2.sha256

1 directory, 3 files
```

Now, file_exists works correctly and only uploads the file when needed:
```
rm ~/Fluendo/fridge/85461631/ENVIRONMENT && tree ~/Fluendo/fridge && ./cerbero-uninstalled -c projects/codecs/1.0/native.cbc edit-cache libffi --steps 'install', 'extract', 'clean_installed_files', 'gen
erate_binary', 'configure', 'post_install', 'delete_rpath', 'compile', 'fetch' && ./cerbero-uninstalled -c projects/codecs/1.0/native.cbc build libffi --upload-binaries && tree ~/Fluendo/fridge
/home/pablo/Fluendo/fridge
└── 85461631
    ├── libffi-linux-x86_64-3.2.9999+git~369ef49f-5c6852d4-devel.tar.bz2
    └── libffi-linux-x86_64-3.2.9999+git~369ef49f-5c6852d4-devel.tar.bz2.sha256

1 directory, 2 files
Loading default configuration from /home/pablo/.cerbero/cerbero.cbc
WARNING: git remote origin URL 'ssh://git@github.com/libffi/libffi.git' uses 'ssh', please only use this for testing
Modifying cache values for recipes: libffi
[libffi]
Before
steps: ['generate_binary', 'fetch', 'install,', 'clean_installed_files,', 'upload_binary', 'post_install,', 'generate_binary,', 'compile,', 'configure,', 'extract,', 'delete_rpath,'], needs_build: False, filepath:
 '/home/pablo/Fluendo/fluendo-cerbero/cerbero/recipes/libffi.recipe', built_version: '3.2.9999+git~369ef49f', file_hash: '5c6852d427fdc3789412e4e16a9746b9ecaff3fcffadf88be8530907e8facfca'
installed_files: ['lib/libffi.so.7.1.0', 'include/ffi.h', 'share/licenses/libffi/README-LICENSE-INFO.txt', 'include/ffitarget.h', 'share/man/man3/ffi.3', 'include/ffi-x86_64.h', 'lib/pkgconfig/libffi.pc', 'share/m
an/man3/ffi_prep_cif.3', 'lib/libffi.so.7', 'share/man/man3/ffi_prep_cif_var.3', 'include/ffitarget-x86_64.h', 'share/man/man3/ffi_call.3', 'lib/libffi.a', 'lib/libffi.la', 'share/licenses/libffi/LICENSE', 'lib/li
bffi.so']

After
steps: ['install,', 'extract,', 'clean_installed_files,', 'generate_binary,', 'configure,', 'post_install,', 'delete_rpath,', 'compile,', 'fetch'], needs_build: False, filepath: '/home/pablo/Fluendo/fluendo-cerber
o/cerbero/recipes/libffi.recipe', built_version: '3.2.9999+git~369ef49f', file_hash: '5c6852d427fdc3789412e4e16a9746b9ecaff3fcffadf88be8530907e8facfca'
installed_files: ['lib/libffi.so.7.1.0', 'include/ffi.h', 'share/licenses/libffi/README-LICENSE-INFO.txt', 'include/ffitarget.h', 'share/man/man3/ffi.3', 'include/ffi-x86_64.h', 'lib/pkgconfig/libffi.pc', 'share/m
an/man3/ffi_prep_cif.3', 'lib/libffi.so.7', 'share/man/man3/ffi_prep_cif_var.3', 'include/ffitarget-x86_64.h', 'share/man/man3/ffi_call.3', 'lib/libffi.a', 'lib/libffi.la', 'share/licenses/libffi/LICENSE', 'lib/li
bffi.so']

Loading default configuration from /home/pablo/.cerbero/cerbero.cbc
WARNING: git remote origin URL 'ssh://git@github.com/libffi/libffi.git' uses 'ssh', please only use this for testing
Building the following recipes: libffi
Fridge initialized with environment hash 85461631
[(1/1 @ 0%) libffi -> generate_binary]
[(1/1 @ 0%) libffi -> upload_binary]
Uploading environment file to ftp://localhost:2121/85461631/ENVIRONMENT
-----> No need to upload since local and remote SHA256 are the same
/home/pablo/Fluendo/fridge
└── 85461631
    ├── ENVIRONMENT
    ├── libffi-linux-x86_64-3.2.9999+git~369ef49f-5c6852d4-devel.tar.bz2
    └── libffi-linux-x86_64-3.2.9999+git~369ef49f-5c6852d4-devel.tar.bz2.sha256

1 directory, 3 files

tree ~/Fluendo/fridge && ./cerbero-uninstalled -c projects/codecs/1.0/native.cbc edit-cache libffi --steps 'install', 'extract', 'clean_installed_files', 'generate_binary', 'configure', 'post_install', 'delete_rpath', 'compile', 'fetch' && ./cerbero-uninstalled -c projects/codecs/1.0/native.cbc build libffi --upload-binaries && tree ~/Fluendo/fridge
/home/pablo/Fluendo/fridge
└── 85461631
    ├── ENVIRONMENT
    ├── libffi-linux-x86_64-3.2.9999+git~369ef49f-5c6852d4-devel.tar.bz2
    └── libffi-linux-x86_64-3.2.9999+git~369ef49f-5c6852d4-devel.tar.bz2.sha256

1 directory, 3 files
Loading default configuration from /home/pablo/.cerbero/cerbero.cbc
WARNING: git remote origin URL 'ssh://git@github.com/libffi/libffi.git' uses 'ssh', please only use this for testing
Modifying cache values for recipes: libffi
[libffi]
Before
steps: ['generate_binary', 'delete_rpath,', 'extract,', 'clean_installed_files,', 'fetch', 'post_install,', 'compile,', 'generate_binary,', 'configure,', 'upload_binary', 'install,'], needs_build: False, filepath: '/home/pablo/Fluendo/fluendo-cerbero/cerbero/recipes/libffi.recipe', built_version: '3.2.9999+git~369ef49f', file_hash: '5c6852d427fdc3789412e4e16a9746b9ecaff3fcffadf88be8530907e8facfca'
installed_files: ['share/man/man3/ffi_call.3', 'lib/libffi.so.7', 'lib/libffi.so.7.1.0', 'lib/libffi.a', 'share/man/man3/ffi_prep_cif_var.3', 'share/licenses/libffi/README-LICENSE-INFO.txt', 'include/ffitarget-x86_64.h', 'include/ffi.h', 'lib/libffi.la', 'share/licenses/libffi/LICENSE', 'share/man/man3/ffi.3', 'lib/pkgconfig/libffi.pc', 'include/ffitarget.h', 'lib/libffi.so', 'share/man/man3/ffi_prep_cif.3', 'include/ffi-x86_64.h']

After
steps: ['install,', 'extract,', 'clean_installed_files,', 'generate_binary,', 'configure,', 'post_install,', 'delete_rpath,', 'compile,', 'fetch'], needs_build: False, filepath: '/home/pablo/Fluendo/fluendo-cerbero/cerbero/recipes/libffi.recipe', built_version: '3.2.9999+git~369ef49f', file_hash: '5c6852d427fdc3789412e4e16a9746b9ecaff3fcffadf88be8530907e8facfca'
installed_files: ['share/man/man3/ffi_call.3', 'lib/libffi.so.7', 'lib/libffi.so.7.1.0', 'lib/libffi.a', 'share/man/man3/ffi_prep_cif_var.3', 'share/licenses/libffi/README-LICENSE-INFO.txt', 'include/ffitarget-x86_64.h', 'include/ffi.h', 'lib/libffi.la', 'share/licenses/libffi/LICENSE', 'share/man/man3/ffi.3', 'lib/pkgconfig/libffi.pc', 'include/ffitarget.h', 'lib/libffi.so', 'share/man/man3/ffi_prep_cif.3', 'include/ffi-x86_64.h']

Loading default configuration from /home/pablo/.cerbero/cerbero.cbc
WARNING: git remote origin URL 'ssh://git@github.com/libffi/libffi.git' uses 'ssh', please only use this for testing
Building the following recipes: libffi
Fridge initialized with environment hash 85461631
[(1/1 @ 0%) libffi -> generate_binary]
[(1/1 @ 0%) libffi -> upload_binary]
-----> No need to upload since local and remote SHA256 are the same
/home/pablo/Fluendo/fridge
└── 85461631
    ├── ENVIRONMENT
    ├── libffi-linux-x86_64-3.2.9999+git~369ef49f-5c6852d4-devel.tar.bz2
    └── libffi-linux-x86_64-3.2.9999+git~369ef49f-5c6852d4-devel.tar.bz2.sha256

1 directory, 3 files
```

Depending on the remote dir, the ENVIRONMENT was always (or never) considered to be present