### PR TITLE
Recipe module for explicit module name resolution

### DIFF
--- a/recipes/gst-editing-services-1.0.recipe
+++ b/recipes/gst-editing-services-1.0.recipe
@@ -1,5 +1,6 @@
 # -*- Mode: Python -*- vi:si:et:sw=4:sts=4:ts=4:syntax=python
 from cerbero.utils import shell
+from recipes import custom
 
 class Recipe(custom.GStreamer):
     name = 'gst-editing-services-1.0'

--- a/recipes/gst-libav-1.0.recipe
+++ b/recipes/gst-libav-1.0.recipe
@@ -1,4 +1,5 @@
 # -*- Mode: Python -*- vi:si:et:sw=4:sts=4:ts=4:syntax=python
+from recipes import custom
 
 class Recipe(custom.GStreamer):
     name = 'gst-libav-1.0'

--- a/recipes/gst-omx-1.0.recipe
+++ b/recipes/gst-omx-1.0.recipe
@@ -1,4 +1,5 @@
 # -*- Mode: Python -*- vi:si:et:sw=4:sts=4:ts=4:syntax=python
+from recipes import custom
 
 class Recipe(custom.GStreamer):
     name = 'gst-omx-1.0'

--- a/recipes/gst-plugins-bad-1.0.recipe
+++ b/recipes/gst-plugins-bad-1.0.recipe
@@ -1,5 +1,6 @@
 # -*- Mode: Python -*- vi:si:et:sw=4:sts=4:ts=4:syntax=python
 from cerbero.tools.libtool import LibtoolLibrary
+from recipes import custom
 
 class Recipe(custom.GStreamer):
     name = 'gst-plugins-bad-1.0'

--- a/recipes/gst-plugins-base-1.0.recipe
+++ b/recipes/gst-plugins-base-1.0.recipe
@@ -1,5 +1,5 @@
 # -*- Mode: Python -*- vi:si:et:sw=4:sts=4:ts=4:syntax=python
-
+from recipes import custom
 
 class Recipe(custom.GStreamer):
     name = 'gst-plugins-base-1.0'

--- a/recipes/gst-plugins-good-1.0.recipe
+++ b/recipes/gst-plugins-good-1.0.recipe
@@ -1,4 +1,5 @@
 # -*- Mode: Python -*- vi:si:et:sw=4:sts=4:ts=4:syntax=python
+from recipes import custom
 
 class Recipe(custom.GStreamer):
     name = 'gst-plugins-good-1.0'

--- a/recipes/gst-plugins-ugly-1.0.recipe
+++ b/recipes/gst-plugins-ugly-1.0.recipe
@@ -1,5 +1,5 @@
 # -*- Mode: Python -*- vi:si:et:sw=4:sts=4:ts=4:syntax=python
-
+from recipes import custom
 
 class Recipe(custom.GStreamer):
     name = 'gst-plugins-ugly-1.0'

--- a/recipes/gst-rtsp-server-1.0.recipe
+++ b/recipes/gst-rtsp-server-1.0.recipe
@@ -1,5 +1,6 @@
 # -*- Mode: Python -*- vi:si:et:sw=4:sts=4:ts=4:syntax=python
 import shutil
+from recipes import custom
 
 class Recipe(custom.GStreamer):
     name = 'gst-rtsp-server-1.0'

--- a/recipes/gst-validate.recipe
+++ b/recipes/gst-validate.recipe
@@ -1,6 +1,7 @@
 # -*- Mode: Python -*- vi:si:et:sw=4:sts=4:ts=4:syntax=python
 from cerbero.utils import shell
 from cerbero.tools.libtool import LibtoolLibrary
+from recipes import custom
 
 class Recipe(custom.GStreamer):
     name = 'gst-validate'

--- a/recipes/gstreamer-1.0.recipe
+++ b/recipes/gstreamer-1.0.recipe
@@ -1,5 +1,5 @@
 # -*- Mode: Python -*- vi:si:et:sw=4:sts=4:ts=4:syntax=python
-import shutil
+from recipes import custom
 
 class Recipe(custom.GStreamer):
     name = 'gstreamer-1.0'


### PR DESCRIPTION
This allows to infer details about the recipe using introspection
outside of the recipe folder more accurately. For example; before
this change using the function inspect.getmro to get the path of a
recipe in the recipes folder from it's class; making this call from
a function outside of the recipes  folder, it will return the class
refreence custom.GStreamer. The problem is if there is another
custom.py in the scope you are calling getmro from. The function
inspect.getmro will do a best guess and may not reference the
correct custom.py. So, by turning the recipes folder in to a module
we get the full class name resolution of recipes.custom.GStreamer;
instead of custom.GStreamer. This avoids any confusion to which
custom.py we are referring to.