### PR TITLE
Fix CMake built missing

### DIFF
--- a/cerbero/bootstrap/build_tools.py
+++ b/cerbero/bootstrap/build_tools.py
@@ -121,14 +121,14 @@ class BuildTools (BootstrapperBase, Fetch):
 
     def start(self):
         self._setup_env()
+        # Check and these at the last minute because we may have installed them
+        # in system bootstrap
+        self.recipes += self.check_build_tools()
         oven = Oven(self.recipes, self.cookbook, missing_files=self.missing_files)
         oven.start_cooking(self.use_binaries, self.upload_binaries)
         self.config.do_setup_env()
 
     def fetch_recipes(self, jobs):
         self._setup_env()
-        # Check and these at the last minute because we may have installed them
-        # in system bootstrap
-        self.recipes += self.check_build_tools()
         Fetch.fetch(self.cookbook, self.recipes, False, False, False, False, jobs, use_binaries=self.use_binaries)
         self.config.do_setup_env()


### PR DESCRIPTION
PR for OPE-1352 introduced a bug in https://github.com/fluendo/cerbero/pull/329
when porting from the community
https://gitlab.freedesktop.org/gstreamer/cerbero/-/commit/efd76aec55ef79e16b76ab2f3779c1ff5b2dc8bf#83d1eb23a2f59cbcfcf605b052cfcabc56517232_107_115

The cmake dependency needs to be added not only when fetching recipes,
but also when building them.