### PR TITLE
source: git: Avoid cloning common sources multiple times

### DIFF
--- a/cerbero/utils/git.py
+++ b/cerbero/utils/git.py
@@ -286,15 +286,10 @@ async def local_checkout(git_dir, local_git_dir, commit, logfile=None):
     @param commit: the commit to checkout
     @type commit: false
     '''
-    # reset to a commit in case it's the first checkout and the masterbranch is
-    # missing
     branch_name = 'cerbero_build'
-    shell.call('%s reset --hard %s' % (GIT, commit), local_git_dir, logfile=logfile)
-    shell.call('%s branch %s' % (GIT, branch_name), local_git_dir, fail=False, logfile=logfile)
-    await shell.async_call('%s checkout %s' % (GIT, branch_name), local_git_dir, logfile=logfile)
-    await shell.async_call('%s reset --hard %s' % (GIT, commit), local_git_dir, logfile=logfile)
-    await shell.async_call('%s clone %s -s -b %s .' % (GIT, local_git_dir, branch_name),
-                           git_dir, logfile=logfile)
+    await shell.async_call([GIT, 'checkout', commit, '-B', branch_name], local_git_dir, logfile=logfile)
+    await shell.async_call([GIT, 'clone', local_git_dir, '-s', '-b', branch_name, '.'],
+               git_dir, logfile=logfile)
     ensure_user_is_set(git_dir, logfile=logfile)
     await submodules_update(git_dir, local_git_dir, logfile=logfile)
 


### PR DESCRIPTION
In some cases, multiple recipes in a cbc may point to the same
git repo. The previous behaviour was to fetch for if recipe. In
this commit, when the repo_dir among multiple recipes is the
same, then only one of them will be fetched and the other
ignored.

There are two cases to ignore fetching a recipe:
 - The recipe was already fetch according the recipe status
 - There is other similar recipe fetching

An asyncio condition is used per group of recipes pointing to a
common git source. It is used to prevent the fetch step done if
there is an-in-progress fetch (for its source); so if the
in-progress feth fails, the others waiting are not considered
fetched in the cache file.

Issue: OCP-1914