### PR TITLE
OCP-2037 Fix CMake not included in fetch step if needed

### DIFF
--- a/cerbero/bootstrap/build_tools.py
+++ b/cerbero/bootstrap/build_tools.py
@@ -121,7 +121,7 @@ class BuildTools (BootstrapperBase, Fetch):
 
     def start(self):
         self._setup_env()
-        # Check and these at the last minute because we may have installed them
+        # Check build tools at the last minute because we may have installed them
         # in system bootstrap
         self.recipes += self.check_build_tools()
         oven = Oven(self.recipes, self.cookbook, missing_files=self.missing_files)
@@ -130,5 +130,8 @@ class BuildTools (BootstrapperBase, Fetch):
 
     def fetch_recipes(self, jobs):
         self._setup_env()
+        # Check build tools at the last minute because we may have installed them
+        # in system bootstrap
+        self.recipes += self.check_build_tools()
         Fetch.fetch(self.cookbook, self.recipes, False, False, False, False, jobs, use_binaries=self.use_binaries)
         self.config.do_setup_env()


### PR DESCRIPTION
Commit 3208cb85fefe31564cb9249bff0cfad1aa4ce772 fixed one issue
but didn't fully covered all cases. It turns out that the build
tools (only CMake as of now) need to be checked after the bootstrap
has done the apt/yum installation.

Previous commit moved the logic to the `start` step, forgetting that
`fetch_recipes` also needs to consider the same. We could do that with
a decorator for both `start` and `fetch_recipes`, but I do not think
it is worth it for what we need to do right now. So, let's keep it
simple and add it in both sides.