### PR TITLE
OCP-2166 Add check-binaries-remote command

### DIFF
--- a/cerbero/bootstrap/build_tools.py
+++ b/cerbero/bootstrap/build_tools.py
@@ -105,6 +105,7 @@ class BuildTools (BootstrapperBase, Fetch):
         config.build_tools_cache = self.config.build_tools_cache
         config.external_recipes = self.config.external_recipes
         config.toolchain_prefix = self.config.toolchain_prefix
+        config.binaries_local = self.config.binaries_local
         config.binaries_remote = self.config.binaries_remote
 
         if config.toolchain_prefix and not os.path.exists(config.toolchain_prefix):

--- a/cerbero/build/fridge.py
+++ b/cerbero/build/fridge.py
@@ -20,7 +20,6 @@
 import os
 import traceback
 import tempfile
-from ftplib import FTP
 import urllib.parse
 import asyncio
 import aioftp
@@ -44,8 +43,8 @@ class BinaryRemote (object):
         '''
         Method to be overriden that fetches a binary
 
-        @param package_names: List of packages to fetch
-        @type package_names: list
+        @param package_name: Package to fetch
+        @type package_name: str
         @param local_dir: Local directory to fetch to
         @type local_dir: str
         @param remote_dir: Remote directory to fetch from where packages exist
@@ -53,15 +52,15 @@ class BinaryRemote (object):
         '''
         raise NotImplementedError
 
-    def upload_binary(self, package_names, local_dir, remote_dir, env_file):
+    def upload_binary(self, package_name, local_dir, remote_dir, env_file):
         '''
         Method to be overriden that uploads a binary
 
-        @param package_names: List of packages to fetch
-        @type package_names: list
-        @param local_dir: Local directory to fetch to
+        @param package_name: Packages to upload
+        @type package_name: str
+        @param local_dir: Local directory to upload from
         @type local_dir: str
-        @param remote_dir: Remote directory to fetch from where packages exist
+        @param remote_dir: Remote directory to upload to where packages exist
         @type remote_dir: str
         '''
         raise NotImplementedError
@@ -83,87 +82,85 @@ class FtpBinaryRemote (BinaryRemote):
         port = 21 if not remote.port else remote.port
         logging.getLogger('aioftp.client').setLevel(logging.CRITICAL)
         async with aioftp.ClientSession(remote.hostname, port, self.username, self.password, socket_timeout=15) as ftp:
-            for filename in package_names:
-                if filename:
-                    local_filename = os.path.join(local_dir, filename)
-                    local_sha256_filename = local_filename + '.sha256'
-                    download_needed = True
-                    remote_sha256_filename = os.path.join(remote.path, remote_dir, filename) + '.sha256'
-                    local_sha256 = 'local_sha256'
-                    remote_sha256 = 'remote_sha256'
+            if package_name:
+                local_filename = os.path.join(local_dir, package_name)
+                local_sha256_filename = local_filename + '.sha256'
+                download_needed = True
+                remote_sha256_filename = os.path.join(remote.path, remote_dir, package_name) + '.sha256'
+                local_sha256 = 'local_sha256'
+                remote_sha256 = 'remote_sha256'
 
-                    await ftp.download(remote_sha256_filename, local_sha256_filename, write_into=True)
-                    # .sha256 file contains both the sha256 hash and the filename, separated by a whitespace
-                    with open(local_sha256_filename, 'r') as file:
-                        remote_sha256 = file.read().split(' ')[0]
+                await ftp.download(remote_sha256_filename, local_sha256_filename, write_into=True)
+                # .sha256 file contains both the sha256 hash and the filename, separated by a whitespace
+                with open(local_sha256_filename, 'r') as file:
+                    remote_sha256 = file.read().split(' ')[0]
 
+                try:
+                    if os.path.isfile(local_filename):
+                        local_sha256 = shell.file_sha256(local_filename).hex()
+                        if local_sha256 == remote_sha256:
+                            download_needed = False
+                except Exception:
+                    pass
+
+                if download_needed:
                     try:
-                        if os.path.isfile(local_filename):
+                        remote_file = os.path.join(remote.path, remote_dir, package_name)
+                        if await ftp.exists(remote_file):
+                            await ftp.download(remote_file, local_filename, write_into=True)
                             local_sha256 = shell.file_sha256(local_filename).hex()
-                            if local_sha256 == remote_sha256:
-                                download_needed = False
+                        else:
+                            raise Exception
                     except Exception:
-                        pass
+                        # Ensure there are no file leftovers
+                        if os.path.exists(local_filename):
+                            os.remove(local_filename)
+                        if os.path.exists(local_sha256_filename):
+                            os.remove(local_sha256_filename)
+                        raise PackageNotFoundError(os.path.join(self.remote, remote_dir, package_name))
 
-                    if download_needed:
-                        try:
-                            remote_file = os.path.join(remote.path, remote_dir, filename)
-                            if await ftp.exists(remote_file):
-                                await ftp.download(remote_file, local_filename, write_into=True)
-                                local_sha256 = shell.file_sha256(local_filename).hex()
-                            else:
-                                raise Exception
-                        except Exception:
-                            # Ensure there are no file leftovers
-                            if os.path.exists(local_filename):
-                                os.remove(local_filename)
-                            if os.path.exists(local_sha256_filename):
-                                os.remove(local_sha256_filename)
-                            raise PackageNotFoundError(os.path.join(self.remote, remote_dir, filename))
+                    if remote_sha256 != local_sha256:
+                        raise Exception('Local file \'{}\' hash \'{}\' is different than expected remote hash \'{}\''
+                                        .format(remote_file, local_sha256, remote_sha256))
 
-                        if remote_sha256 != local_sha256:
-                            raise Exception('Local file \'{}\' hash \'{}\' is different than expected remote hash \'{}\''
-                                            .format(remote_file, local_sha256, remote_sha256))
-
-    def upload_binary(self, package_names, local_dir, remote_dir, env_file):
+    def upload_binary(self, package_name, local_dir, remote_dir, env_file):
         ftp = Ftp(self.remote, user=self.username, password=self.password)
         remote_env_file = os.path.join(self.remote, remote_dir, os.path.basename(env_file))
         if not ftp.file_exists(remote_env_file):
             m.message('Uploading environment file to %s' % remote_env_file)
             ftp.upload(env_file, remote_env_file)
-        for filename in package_names:
-            if filename:
-                remote_filename = os.path.join(self.remote, remote_dir, filename)
-                remote_sha256_filename = remote_filename + '.sha256'
-                local_filename = os.path.join(local_dir, filename)
-                local_sha256_filename = local_filename + '.sha256'
-                upload_needed = True
+        if package_name:
+            remote_filename = os.path.join(self.remote, remote_dir, package_name)
+            remote_sha256_filename = remote_filename + '.sha256'
+            local_filename = os.path.join(local_dir, package_name)
+            local_sha256_filename = local_filename + '.sha256'
+            upload_needed = True
 
-                sha256 = shell.file_sha256(local_filename)
-                # .sha256 file contains both the sha256 hash and the
-                # filename, separated by a whitespace
-                with open(local_sha256_filename, 'w') as f:
-                    f.write('%s %s' % (sha256.hex(), filename))
+            sha256 = shell.file_sha256(local_filename)
+            # .sha256 file contains both the sha256 hash and the
+            # filename, separated by a whitespace
+            with open(local_sha256_filename, 'w') as f:
+                f.write('%s %s' % (sha256.hex(), package_name))
 
-                try:
-                    tmp_sha256 = tempfile.NamedTemporaryFile()
-                    tmp_sha256_filename = tmp_sha256.name
-                    ftp.download(remote_sha256_filename,
-                                 tmp_sha256_filename)
-                    with open(local_sha256_filename, 'r') as file:
-                        local_sha256 = file.read().split()[0]
-                    with open(tmp_sha256_filename, 'r') as file:
-                        remote_sha256 = file.read().split()[0]
-                    if local_sha256 == remote_sha256:
-                        upload_needed = False
-                except Exception:
-                    pass
+            try:
+                tmp_sha256 = tempfile.NamedTemporaryFile()
+                tmp_sha256_filename = tmp_sha256.name
+                ftp.download(remote_sha256_filename,
+                                tmp_sha256_filename)
+                with open(local_sha256_filename, 'r') as file:
+                    local_sha256 = file.read().split()[0]
+                with open(tmp_sha256_filename, 'r') as file:
+                    remote_sha256 = file.read().split()[0]
+                if local_sha256 == remote_sha256:
+                    upload_needed = False
+            except Exception:
+                pass
 
-                if upload_needed:
-                    ftp.upload(local_sha256_filename, remote_sha256_filename)
-                    ftp.upload(local_filename, remote_filename)
-                else:
-                    m.action('No need to upload since local and remote SHA256 are the same for filename: {}'.format(filename))
+            if upload_needed:
+                ftp.upload(local_sha256_filename, remote_sha256_filename)
+                ftp.upload(local_filename, remote_filename)
+            else:
+                m.action('No need to upload since local and remote SHA256 are the same for filename: {}'.format(package_name))
         ftp.close()
 
 
@@ -231,7 +228,7 @@ class Fridge (object):
         self._ensure_ready(recipe)
         try:
             # Ensure the built_version is collected asynchronously before
-            # calling _get_package_names, because that is done in a sync way and
+            # calling _get_package_name, because that is done in a sync way and
             # would call otherwise the sync built_version, which takes time.
             # Since the built_version is cached, we can gather it here and will be
             # reused by both the sync and async flavors of built_version
@@ -250,30 +247,29 @@ class Fridge (object):
 
     async def fetch_binary(self, recipe):
         self._ensure_ready(recipe)
-        package_names = self._get_package_names(recipe).values()
-        m.action('Downloading fridge package {}/{}'.format(self.env_checksum, list(package_names)[0]))
-        await self.binaries_remote.fetch_binary(package_names,
+        package_name = self._get_package_name(recipe)
+        m.action('Downloading fridge package {}/{}'.format(self.env_checksum, package_name))
+        await self.binaries_remote.fetch_binary(package_name,
                                           self.binaries_local, self.env_checksum)
 
     def extract_binary(self, recipe):
         self._ensure_ready(recipe)
-        package_names = self._get_package_names(recipe)
+        package_name = self._get_package_name(recipe)
         # There is a weird bug where the links in the devel package are overwriting the
         # file it's linking instead of just creating the link.
         # For example libmonosgen-2.0.dylib will be extracted creating a link
         # libmonosgen-2.0.dylib -> libmonosgen-2.0.1.dylib and copying
         # libmonosgen-2.0.dylib to libmonosgen-2.0.1.dylib
         # As a workaround we extract first the devel package and finally the runtime
-        for filename in package_names.values():
-            if filename:
-                if self.config.target_platform == Platform.DARWIN:
-                    tarclass = RelocatableTarOSX
-                else:
-                    tarclass = RelocatableTar
-                tar = tarclass.open(os.path.join(self.binaries_local,
-                                                 filename), 'r:bz2')
-                tar.extract_and_relocate(self.config.prefix, self.config.toolchain_prefix)
-                tar.close()
+        if package_name:
+            if self.config.target_platform == Platform.DARWIN:
+                tarclass = RelocatableTarOSX
+            else:
+                tarclass = RelocatableTar
+            tar = tarclass.open(os.path.join(self.binaries_local,
+                                                package_name), 'r:bz2')
+            tar.extract_and_relocate(self.config.prefix, self.config.toolchain_prefix)
+            tar.close()
 
     def generate_binary(self, recipe):
         self._ensure_ready(recipe)
@@ -292,14 +288,13 @@ class Fridge (object):
 
     def upload_binary(self, recipe):
         self._ensure_ready(recipe)
-        packages = self._get_package_names(recipe)
-        fetch_packages = []
-        for p in packages.values():
-            if os.path.exists(os.path.join(self.binaries_local, p)):
-                fetch_packages.append(p)
-            else:
-                m.warning("No package was created for %s" % p)
-        self.binaries_remote.upload_binary(fetch_packages, self.binaries_local,
+        package = self._get_package_name(recipe)
+        fetch_package = None
+        if os.path.exists(os.path.join(self.binaries_local, package)):
+            fetch_package = package
+        else:
+            m.warning("No package was created for %s" % package)
+        self.binaries_remote.upload_binary(fetch_package, self.binaries_local,
                                            self.env_checksum, self.env_file)
 
     def _ensure_ready(self, recipe):
@@ -318,12 +313,10 @@ class Fridge (object):
                     f.write('%s\n\n%s' % (self.env_checksum, self.config.get_string_for_checksum()))
             m.message('Fridge initialized with environment hash {}'.format(self.env_checksum))
 
-    def _get_package_names(self, recipe):
-        ret = dict()
+    def _get_package_name(self, recipe):
         p = self.store.get_package('%s-pkg' % recipe.name)
         tar = DistTarball(self.config, p, self.store)
-        ret[PackageType.DEVEL] = tar.get_name(PackageType.DEVEL)
-        return ret
+        return tar.get_name(PackageType.DEVEL)
 
     async def _apply_steps(self, recipe, steps, build_status_printer, count):
         self._ensure_ready(recipe)

--- a/cerbero/build/fridge.py
+++ b/cerbero/build/fridge.py
@@ -89,8 +89,9 @@ class FtpBinaryRemote (BinaryRemote):
 
     def binary_exists(self, package_name, remote_dir):
         exists = False
+        remote = urllib.parse.urlparse(self.remote)
         with Ftp(self.remote, user=self.username, password=self.password) as ftp:
-            exists = ftp.file_exists(os.path.join(remote_dir, package_name))
+            exists = ftp.file_exists(os.path.join(remote.path, remote_dir, package_name))
         return exists
 
     async def fetch_binary(self, package_name, local_dir, remote_dir):
@@ -141,12 +142,13 @@ class FtpBinaryRemote (BinaryRemote):
 
     def upload_binary(self, package_name, local_dir, remote_dir, env_file):
         with Ftp(self.remote, user=self.username, password=self.password) as ftp:
-            remote_env_file = os.path.join(self.remote, remote_dir, os.path.basename(env_file))
+            remote = urllib.parse.urlparse(self.remote)
+            remote_env_file = os.path.join(remote.path, remote_dir, os.path.basename(env_file))
             if not ftp.file_exists(remote_env_file):
                 m.action('Uploading environment file to %s' % remote_env_file)
                 ftp.upload(env_file, remote_env_file)
             if package_name:
-                remote_filename = os.path.join(self.remote, remote_dir, package_name)
+                remote_filename = os.path.join(remote.path, remote_dir, package_name)
                 remote_sha256_filename = remote_filename + '.sha256'
                 local_filename = os.path.join(local_dir, package_name)
                 local_sha256_filename = local_filename + '.sha256'

--- a/cerbero/commands/check_binaries_remote.py
+++ b/cerbero/commands/check_binaries_remote.py
@@ -44,7 +44,7 @@ class CheckBinariesRemote(Command):
         tasks = []
         for recipe_name in args.recipes:
             recipe = cookbook.get_recipe(recipe_name)
-            tasks.append(fridge.check_remote_package_exists(recipe))
+            tasks.append(fridge.check_remote_binary_exists(recipe))
 
         run_until_complete(tasks)
 

--- a/cerbero/commands/check_binaries_remote.py
+++ b/cerbero/commands/check_binaries_remote.py
@@ -1,0 +1,47 @@
+# cerbero - a multi-platform build system for Open Source software
+# Copyright (C) 2021, Fluendo, S.A.
+#  Author: Pablo Marcos Oltra <pmarcos@fluendo.com>, Fluendo, S.A.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+
+from cerbero.commands import Command, register_command
+from cerbero.build.cookbook import CookBook
+from cerbero.utils import _, N_, ArgparseArgument, run_until_complete
+from cerbero.build.fridge import Fridge
+from cerbero.packages.packagesstore import PackagesStore
+
+
+class CheckBinariesRemote(Command):
+    doc = N_('Checks if a binary remote package exists')
+    name = 'check-binaries-remote'
+
+    def __init__(self):
+        Command.__init__(self,
+            [ArgparseArgument('recipe', nargs=1,
+                             help=_('name of the recipe to check')),
+            ])
+
+    def run(self, config, args):
+        cookbook = CookBook(config)
+        recipe_name = args.recipe[0]
+
+        recipe = cookbook.get_recipe(recipe_name)
+        fridge = Fridge(PackagesStore(cookbook.get_config(), recipes=recipe, cookbook=cookbook))
+        return run_until_complete(fridge.check_remote_package_exists(recipe))
+
+
+register_command(CheckBinariesRemote)

--- a/cerbero/commands/fetch.py
+++ b/cerbero/commands/fetch.py
@@ -26,7 +26,7 @@ from cerbero.build.cookbook import CookBook
 from cerbero.enums import LibraryType
 from cerbero.errors import FatalError
 from cerbero.packages.packagesstore import PackagesStore
-from cerbero.utils import _, N_, ArgparseArgument, remove_list_duplicates, git, shell, determine_num_of_cpus, run_until_complete
+from cerbero.utils import _, N_, ArgparseArgument, remove_list_duplicates, git, shell, run_until_complete
 from cerbero.utils import messages as m
 from cerbero.build.source import Tarball
 from cerbero.config import Distro

--- a/cerbero/utils/shell.py
+++ b/cerbero/utils/shell.py
@@ -528,6 +528,12 @@ class Ftp:
         with open(local_filename, 'rb') as f:
             self.ftp.storbinary('STOR ' + os.path.basename(remote.path), f)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
 
 def _splitter(string, base_url):
     lines = string.split('\n')

--- a/docs/fridge.md
+++ b/docs/fridge.md
@@ -23,8 +23,20 @@ packages will live.
 
 Apart from the environment hash, a hash is generated per recipe to allow having
 different versions. The recipe hash is taken from a checksum of all the files
-involving it (the recipe itself + patches) and the version that it's using. For
-recipes using a git repo as its source, that means the commit it's based upon.
+involving it (the recipe itself + patches), the version that it's using and in
+case `strict_recipe_checksum` is set to True, also all its parent classes and
+dependencies checksums. For recipes using a git repo as its source, their
+version includes the commit it's based upon.
+
+This is a comprehensive list that shows the changes that affect the package
+name:
+
+* The recipe content
+* Any of the patches' content, or a new one is added
+* The commit hash a recipe is pointing to
+* If `strict_recipe_checksum=True`
+  * Any of the non-builtin parent's classes of the recipe
+  * Any of the recipe dependencies
 
 # What is packaged
 


### PR DESCRIPTION
Add a new `check-binaries-remote` command to check whether remote binaries in fridge exists or not:

```
./cerbero-uninstalled -t -c cerbero/test.cbc check-binaries-remote zlib; echo $?
0:00:00.001785 Loading default configuration from /home/pablo/.cerbero/cerbero.cbc
0:00:00.037679 Fridge initialized with environment hash fb61b54d
0:00:00.184435 -----> Checking if fridge package exists fb61b54d/zlib-linux-x86_64-1.2.11-f5a8fab9-devel.tar.bz2
0:00:00.188274 ***** Error running 'check-binaries-remote' command:
0:00:00.188297 Package 'ftp://localhost:2121/fb61b54d/zlib-linux-x86_64-1.2.11-f5a8fab9-devel.tar.bz2' not found
1
```

```
./cerbero-uninstalled -t -c cerbero/test.cbc check-binaries-remote test; echo $?
0:00:00.001669 Loading default configuration from /home/pablo/.cerbero/cerbero.cbc
0:00:00.021932 Fridge initialized with environment hash fb61b54d
0:00:00.146494 -----> Checking if fridge package exists fb61b54d/test-linux-x86_64-0.10+git~b01e0e12-16dd6c7d-devel.tar.bz2
0:00:00.149894 Package exists in remote
0
```