### PR TITLE
OCP-2170 Use host and target info for env instead of compiler  version

### DIFF
--- a/cerbero/config.py
+++ b/cerbero/config.py
@@ -399,7 +399,15 @@ class Config (object):
                'PYTHONPATH': pythonpath,
                'MONO_PATH': os.path.join(libdir, 'mono', '4.5'),
                'MONO_GAC_PREFIX': prefix,
-               'GSTREAMER_ROOT': prefix
+               'GSTREAMER_ROOT': prefix,
+               'PLATFORM': self.platform,
+               'TARGET_PLATFORM': self.target_platform,
+               'ARCH': self.arch,
+               'TARGET_ARCH': self.target_arch,
+               'DISTRO': self.distro,
+               'TARGET_DISTRO': self.target_distro,
+               'DISTRO_VERSION': self.distro_version,
+               'TARGET_DISTRO_VERSION': self.target_distro_version,
                }
 
         return env
@@ -561,9 +569,6 @@ class Config (object):
             v = replace_prefix(os.path.expanduser('~'), v, '{USER}')
             ret_env[e] = re.sub(r'\s+', ' ', v.strip())
 
-        # We need to add the compiler version after the bootstrap phase because
-        # there is no compiler installed yet and get_env is cached
-        ret_env['CC_VERSION'] = shell.check_compiler_version(self, self.env.get('CC'))
         return ret_env
 
     def _parse(self, filename, reset=True):

--- a/cerbero/utils/shell.py
+++ b/cerbero/utils/shell.py
@@ -739,24 +739,6 @@ def check_perl_version(needed, env):
     return perl, found, newer
 
 
-def check_compiler_version(config, cc):
-    '''
-    Returns the compiler version
-    @param config: Configuration
-    @type config: L{cerbero.config.Config}
-    @param cc: Compiler
-    @type cc: str
-    '''
-    if 'gcc' in cc or 'clang' in cc or not config.msvc_version:
-        result = re.search(r'\s(\d+\.\d+\.\d+(\.\d+)?)\s', check_output(cc + ' --version'))
-        if result.groups():
-            return result.groups()[0]
-        else:
-            raise FatalError(_('Cannot retrieve version of the compiler'))
-    else:
-        return config.msvc_version
-
-
 def windows_proof_rename(from_name, to_name):
     '''
     On Windows, if you try to rename a file or a directory that you've newly

--- a/docs/fridge.md
+++ b/docs/fridge.md
@@ -12,14 +12,14 @@ configure and compile steps, which are arguably the most time-consuming ones.
 ## How recipes are reused
 
 A hash is generated for the current environment used in the configuration. This
-means everything that `config::get_env` considers plus the compiler version.
-e.g. the linker flags, include dir, LD_LIBRARY_PATH, etc. Hence, the idea is to
-reuse the same binaries already built in a conservative way to ensure they will
-work. The environment is sanitized before creating the hash, so that the prefix,
+means everything that `config::get_env` considers. e.g. the linker flags,
+include dir, LD_LIBRARY_PATH, etc. Hence, the idea is to reuse the same
+binaries already built in a conservative way to ensure they will work. The
+environment is sanitized before creating the hash, so that the prefix,
 Cerbero's home and user's home are normalized. Apart from that, the package
-naming already contains the target platform and target architecture. A directory
-is created for each of the configurations (aka. environments) where prebuilt
-packages will live.
+naming already contains the target platform and target architecture. A
+directory is created for each of the configurations (aka. environments) where
+prebuilt packages will live.
 
 Apart from the environment hash, a hash is generated per recipe to allow having
 different versions. The recipe hash is taken from a checksum of all the files
@@ -72,15 +72,17 @@ Additionally, every environment directory includes an `ENVIRONMENT` file
 containing the list of all the variables considered to generate the hash:
 
 ```
-9beba1f2
+96c0de0d
 
 ACLOCAL=aclocal
 ACLOCAL_FLAGS=-I{PREFIX}/share/aclocal
-CC=clang
-CC_VERSION=10.0.0
-CFLAGS=-Wall -g -O2 -arch x86_64 -m64 -Wno-error=format-nonliteral -I{PREFIX}/include -mmacosx-version-min=10.10 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk
+ARCH=x86_64
+CC=gcc
+CFLAGS=-Wall -g -O2 -m64 -Wall -g -O2 -m64
 CPLUS_INCLUDE_PATH={PREFIX}/include
 C_INCLUDE_PATH={PREFIX}/include
+DISTRO=debian
+DISTRO_VERSION=ubuntu_20_04_focal
 GI_TYPELIB_PATH={PREFIX}/lib/girepository-1.0
 GSTREAMER_ROOT={PREFIX}
 GST_PLUGIN_PATH={PREFIX}/lib/gstreamer-0.10
@@ -88,19 +90,24 @@ GST_PLUGIN_PATH_1_0={PREFIX}/lib/gstreamer-1.0
 GST_REGISTRY={USER}/.gstreamer-0.10/cerbero-registry-x86_64
 GST_REGISTRY_1_0={USER}/.cache/gstreamer-1.0/cerbero-registry-x86_64
 INFOPATH={PREFIX}/share/info
-LDFLAGS=-L{PREFIX}/lib -headerpad_max_install_names -Wl,-headerpad_max_install_names -Wno-error=unused-command-line-argument -arch x86_64 -m64 -Wl,-arch,x86_64 -mmacosx-version-min=10.10 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk
-LD_LIBRARY_PATH={PREFIX}/lib:{PREFIX}/lib:{PREFIX}/bin:/opt/local/bin:/opt/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/share/dotnet:~/.dotnet/tools:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Applications/Xamarin Workbooks.app/Contents/SharedSupport/path-bin
+LDFLAGS=-L{PREFIX}/lib -m64 -m64
+LD_LIBRARY_PATH={PREFIX}/lib:{HOME}/build-tools/lib
 MANPATH={PREFIX}/share/man
 MONO_GAC_PREFIX={PREFIX}
 MONO_PATH={PREFIX}/lib/mono/4.5
-PERL5LIB={PREFIX}/lib/perl5:{PREFIX}/lib/perl5/site_perl/5.18.2
-PKG_CONFIG={PREFIX}/bin/pkg-config
+PERL5LIB={PREFIX}/lib/perl5:{PREFIX}/lib/perl5/site_perl/5.32.1
+PKG_CONFIG={HOME}/build-tools/bin/pkg-config
 PKG_CONFIG_LIBDIR={PREFIX}/lib/pkgconfig
 PKG_CONFIG_PATH={PREFIX}/share/pkgconfig
-PYTHONPATH={PREFIX}/lib/python3.7/site-packages/:{PREFIX}/lib/python3.7/site-packages/
+PLATFORM=linux
+PYTHONPATH={PREFIX}/lib/python3.9/site-packages/:{HOME}/build-tools/lib/python3.9/site-packages/
+TARGET_ARCH=x86_64
+TARGET_DISTRO=debian
+TARGET_DISTRO_VERSION=ubuntu_20_04_focal
+TARGET_PLATFORM=linux
 XCURSOR_PATH={PREFIX}/share/icons
 XDG_CONFIG_DIRS={PREFIX}/etc/xdg
-XDG_DATA_DIRS={PREFIX}/share
+XDG_DATA_DIRS={PREFIX}/share:/usr/share:/usr/local/share
 ```
 
 The following directory contains the packages of yasm and zlib recipes for macOS


### PR DESCRIPTION
This is a trade-off to favor simplicity and speed
over safety. The reasoning behind this is that if
we do not need the compiler version, we can use
fridge before bootstrapping with consistency. Take
into account that bootstrap process may install a
different or newer compiler version.

Thus, this way we can use check-binaries-remote
before doing anything at all without needing to
bootstrap first. In any case, we add some nice
info for both host and target to ensure minimum
ABI compatibility.