### PR TITLE
OPE-1599 Add CERBERO_VARIANTS to env checksum for fridge

### DIFF
--- a/cerbero/config.py
+++ b/cerbero/config.py
@@ -536,6 +536,7 @@ class Config (object):
         # platforms to ensure that the checksum is different whenever
         # some of them change. This is a lazy attempt to ensure ABI
         # compatibility.
+        sorted_variants = ['\'{}\': {}'.format(k, v) for k,v in sorted(self.variants.__dict__.items())]
         env.update({'PLATFORM': self.platform,
             'TARGET_PLATFORM': self.target_platform,
             'ARCH': self.arch,
@@ -544,6 +545,7 @@ class Config (object):
             'TARGET_DISTRO': self.target_distro,
             'DISTRO_VERSION': self.distro_version,
             'TARGET_DISTRO_VERSION': self.target_distro_version,
+            'CERBERO_VARIANTS': '{{{}}}'.format(', '.join(sorted_variants))
             })
         string = ''
         for e in sorted(env.keys()):

--- a/docs/fridge.md
+++ b/docs/fridge.md
@@ -72,12 +72,13 @@ Additionally, every environment directory includes an `ENVIRONMENT` file
 containing the list of all the variables considered to generate the hash:
 
 ```
-96c0de0d
+73f25829
 
 ACLOCAL=aclocal
 ACLOCAL_FLAGS=-I{PREFIX}/share/aclocal
 ARCH=x86_64
 CC=gcc
+CERBERO_VARIANTS=<Variants: {'debug': True, 'python': True, 'testspackage': True, 'x11': True, 'alsa': True, 'pulse': True, 'cdparanoia': False, 'v4l2': True, 'gi': True, 'unwind': True, 'rpi': False, 'visualstudio': False, 'qt5': False, 'intelmsdk': False, 'nvcodec': False, 'werror': False, 'gst1': False, 'sdl': False, 'clutter': False, 'gtk': False, 'strip': True, 'fluffgst_demo': False, 'static': True, 'va': True}>
 CFLAGS=-Wall -g -O2 -m64 -Wall -g -O2 -m64
 CPLUS_INCLUDE_PATH={PREFIX}/include
 C_INCLUDE_PATH={PREFIX}/include


### PR DESCRIPTION
This ensures that recipes that have different logic
depending on the variant don't clash when generating
the fridge package.