### PR TITLE
OCP-2216 Fix different checksum depending on deps order

### DIFF
--- a/cerbero/build/recipe.py
+++ b/cerbero/build/recipe.py
@@ -557,7 +557,7 @@ SOFTWARE LICENSE COMPLIANCE.\n\n'''
         Add to the given SHA256 the checksum of its dependencies in case
         they are static
         '''
-        deps = self.list_deps()
+        deps = sorted(set(self.list_deps()))
         for dep in deps:
             recipe = self.config.cookbook.get_recipe(dep)
             sha256.update(recipe.get_checksum().encode('utf-8'))

--- a/cerbero/build/source.py
+++ b/cerbero/build/source.py
@@ -129,7 +129,7 @@ class Source (object):
         files = list(map(self.relative_path, self.patches))
         if hasattr(self, '__file__'):
             files.append(self.__file__)
-        return files
+        return sorted(set(files))
 
 
 class CustomSource (Source):


### PR DESCRIPTION
For some reason, fluendo-sdk recipe includes duplicated
deps. Also, they might be included in different order.
So, let's do some defensive programming in all the lists
considered for the checksum of the recipe to ensure
consistency across different runs.

This was already done for the parents checksum, but I
wrongly assumed that list_deps() returned a sorted list.