### PR TITLE
OPE-1636 Workaround for FTP server not replying 550

### DIFF
--- a/cerbero/utils/shell.py
+++ b/cerbero/utils/shell.py
@@ -513,6 +513,8 @@ class Ftp:
             return False
 
     def download(self, remote_url, local_filename):
+        if not self.file_exists(remote_url):
+            raise Exception('Remote file {} does not exist'.format(remote_url))
         remote = urllib.parse.urlparse(remote_url)
         self.ftp.cwd(os.path.dirname(remote.path))
         with open(local_filename, 'wb') as f:


### PR DESCRIPTION
For some reason, offficestorage's FTP server now replies
with an empty line and closes the connection when trying
to download a file that does not exist. As a workaround,
let's only try to download files after verifying that
they actually exist.