### PR TITLE
OCP-2206: git: Prevent fetching submodules if no git modules present

### DIFF
--- a/cerbero/utils/git.py
+++ b/cerbero/utils/git.py
@@ -19,9 +19,10 @@
 import os
 import time
 import shutil
+import cerbero.utils.messages as m
 
 from cerbero.config import Platform
-from cerbero.utils import shell, run_until_complete
+from cerbero.utils import shell, run_until_complete, _
 from cerbero.errors import FatalError
 
 GIT = 'git'
@@ -154,6 +155,10 @@ async def submodules_update(git_dir, src_dir=None, fail=True, offline=False, log
     @param offline: don't use the network
     @type offline: false
     '''
+    if not os.path.exists(os.path.join(git_dir, '.gitmodules')):
+        m.log(_(".gitmodules does not exist in %s. No need to fetch submodules.") % git_dir, logfile)
+        return
+
     if src_dir:
         config = shell.check_call('%s config --file=.gitmodules --list' % GIT,
                                   git_dir)


### PR DESCRIPTION
It skips an error when fetching submodules (which is the default behaviour) in repos not using submodules.
Supporting fail, would involve touching too much parts of fluendo-cerbero, and we prefer to avoid that and keep it simple.