### PR TITLE
OCP-2247 Fix percentage shown in build steps that include fridge

### DIFF
--- a/cerbero/build/fridge.py
+++ b/cerbero/build/fridge.py
@@ -211,16 +211,15 @@ class Fridge (object):
             if hasattr(recipe, 'async_built_version'):
                 await recipe.async_built_version()
             package_name = self._get_package_name(recipe)
-            m.action('Checking if fridge binary exists {}/{}'.format(self.env_checksum, package_name))
             if self.binaries_remote.binary_exists(package_name, self.env_checksum):
-                m.message('Package exists in remote')
+                m.action('{}: Remote package \'{}/{}\' found'.format(recipe, self.env_checksum, package_name))
             else:
-                raise PackageNotFoundError(os.path.join(self.binaries_remote.remote, self.env_checksum, package_name))
+                raise PackageNotFoundError(os.path.join(self.env_checksum, package_name))
         except PackageNotFoundError:
             raise
         except Exception as e:
             m.warning('Error checking if recipe %s exists in remote: %s' % (recipe.name, e))
-            raise PackageNotFoundError(os.path.join(self.binaries_remote.remote, self.env_checksum, package_name))
+            raise PackageNotFoundError(os.path.join(self.env_checksum, package_name))
 
     async def fetch_binary(self, recipe):
         self._ensure_ready(recipe)

--- a/cerbero/build/fridge.py
+++ b/cerbero/build/fridge.py
@@ -277,7 +277,7 @@ class Fridge (object):
             await self._apply_steps(recipe, [self.FETCH_BINARY], build_status_printer, count)
         except Exception:
             # Fallback to fetch the source instead
-            build_status_printer.update_recipe_step(count, recipe.name, 'fetch')
+            build_status_printer.update_recipe_step(count, recipe, 'fetch')
             if not self.cookbook.step_done(recipe.name, 'fetch'):
                 await recipe.fetch()
                 self.cookbook.update_step_status(recipe.name, 'fetch')
@@ -362,7 +362,7 @@ class Fridge (object):
     async def _apply_steps(self, recipe, steps, build_status_printer, count):
         self._ensure_ready(recipe)
         for _, step in steps:
-            build_status_printer.update_recipe_step(count, recipe.name, step)
+            build_status_printer.update_recipe_step(count, recipe, step)
             # check if the current step needs to be done
             if self.cookbook.step_done(recipe.name, step) and not self.force:
                 m.action("Step done")

--- a/cerbero/build/oven.py
+++ b/cerbero/build/oven.py
@@ -115,10 +115,7 @@ class Oven (object):
             fridge = Fridge(PackagesStore(self.config, recipes=ordered_recipes, cookbook=self.cookbook),
                             force=self.force, dry_run=shell.DRY_RUN)
 
-        steps = [step[1] for step in recipes[0].steps]
-        if upload_binaries:
-            steps += [Fridge.GEN_BINARY, Fridge.UPLOAD_BINARY]
-        self._build_status_printer = BuildStatusPrinter(steps)
+        self._build_status_printer = BuildStatusPrinter()
         self._build_status_printer.total = length
         self._static_libraries_built = []
         i = 1
@@ -198,7 +195,7 @@ class Oven (object):
         recipe.force = self.force
         steps_run = []
         for desc, step in recipe.steps:
-            self._build_status_printer.update_recipe_step(count, recipe.name, step)
+            self._build_status_printer.update_recipe_step(count, recipe, step)
             # check if the current step needs to be done
             if self.cookbook.step_done(recipe.name, step) and not self.force:
                 m.action(_("Step done"))

--- a/cerbero/build/oven.py
+++ b/cerbero/build/oven.py
@@ -118,7 +118,7 @@ class Oven (object):
         steps = [step[1] for step in recipes[0].steps]
         if upload_binaries:
             steps += [Fridge.GEN_BINARY, Fridge.UPLOAD_BINARY]
-        self._build_status_printer = BuildStatusPrinter(steps, False) #self.interactive)
+        self._build_status_printer = BuildStatusPrinter(steps)
         self._build_status_printer.total = length
         self._static_libraries_built = []
         i = 1

--- a/cerbero/commands/fetch.py
+++ b/cerbero/commands/fetch.py
@@ -71,9 +71,8 @@ class Fetch(Command):
         fridge = None
         if use_binaries:
             fridge = Fridge(PackagesStore(cookbook.get_config(), recipes=fetch_recipes, cookbook=cookbook))
-            printer = BuildStatusPrinter([Fridge.FETCH_BINARY, Fridge.EXTRACT_BINARY])
-        else:
-            printer = BuildStatusPrinter (('fetch',))
+
+        printer = BuildStatusPrinter()
         printer.total = len(fetch_recipes)
 
         async def _fetch(cookbook, recipe):
@@ -100,7 +99,7 @@ class Fetch(Command):
             if asyncio.iscoroutinefunction(stepfunc):
                 tasks.append(_fetch(cookbook, recipe))
             else:
-                printer.update_recipe_step(printer.count, recipe.name, 'fetch')
+                printer.update_recipe_step(printer.count, recipe, 'fetch')
                 stepfunc()
                 printer.count += 1
                 printer.remove_recipe(recipe.name)

--- a/cerbero/commands/fetch.py
+++ b/cerbero/commands/fetch.py
@@ -71,9 +71,9 @@ class Fetch(Command):
         fridge = None
         if use_binaries:
             fridge = Fridge(PackagesStore(cookbook.get_config(), recipes=fetch_recipes, cookbook=cookbook))
-            printer = BuildStatusPrinter([Fridge.FETCH_BINARY, Fridge.EXTRACT_BINARY], False) #cookbook.get_config().interactive)
+            printer = BuildStatusPrinter([Fridge.FETCH_BINARY, Fridge.EXTRACT_BINARY])
         else:
-            printer = BuildStatusPrinter (('fetch',), False) #cookbook.get_config().interactive)
+            printer = BuildStatusPrinter (('fetch',))
         printer.total = len(fetch_recipes)
 
         async def _fetch(cookbook, recipe):

--- a/cerbero/errors.py
+++ b/cerbero/errors.py
@@ -68,7 +68,7 @@ class RecipeNotFoundError(CerberoException):
 class PackageNotFoundError(CerberoException):
 
     def __init__(self, package):
-        CerberoException.__init__(self, _("Package '%s' not found") % package)
+        CerberoException.__init__(self, _("Remote package '%s' not found") % package)
 
 
 class EmptyPackageError(CerberoException):

--- a/cerbero/errors.py
+++ b/cerbero/errors.py
@@ -97,4 +97,4 @@ class AbortedError(Exception):
 class RecipeNotFreezableError(CerberoException):
 
     def __init__(self, recipe):
-        CerberoException.__init__(self, _("Recipe '%s' is not freezable") % recipe)
+        CerberoException.__init__(self, _("Recipe '%s' is not freezable (allow_package_creation = False)") % recipe)

--- a/cerbero/utils/shell.py
+++ b/cerbero/utils/shell.py
@@ -762,37 +762,22 @@ def windows_proof_rename(from_name, to_name):
 
 
 class BuildStatusPrinter:
-    def __init__(self, steps):
-        self.steps = steps[:]
+    def __init__(self):
         self.step_to_recipe = collections.defaultdict(list)
         self.recipe_to_step = {}
         self.total = 0
         self.count = 0
 
-    def remove_recipe(self, recipe_name):
-        if recipe_name in self.recipe_to_step:
-            self.step_to_recipe[self.recipe_to_step[recipe_name]].remove(recipe_name)
-            del self.recipe_to_step[recipe_name]
-
-    def built(self, count, recipe_name):
-        self.count += 1
-        self.remove_recipe(recipe_name)
-
-    def already_built(self, count, recipe_name):
-        self.count += 1
-        m.build_recipe_done(count, self.total, recipe_name, _("already built"))
-
-    def _get_completion_percent(self):
+    def _get_completion_percent(self, step, all_steps):
         one_recipe = 100. / float(self.total)
-        one_step = one_recipe / len(self.steps)
+        one_step = one_recipe / len(all_steps)
         completed = 100. * float(self.count - 1) / float(self.total)
-        for i, step in enumerate(self.steps):
-            completed += len(self.step_to_recipe[step]) * (i+1) * one_step
+        for i, s in enumerate(all_steps):
+            if step == s[1]:
+                completed += i * one_step
         return int(completed)
 
-    def update_recipe_step(self, count, recipe_name, step):
-        self.remove_recipe(recipe_name)
-        self.step_to_recipe[step].append(recipe_name)
-        self.recipe_to_step[recipe_name] = step
+    def update_recipe_step(self, count, recipe, step):
+        recipe_name = recipe.name
         self.count = count
-        m.build_step(count, self.total, self._get_completion_percent(), recipe_name, step)
+        m.build_step(count, self.total, self._get_completion_percent(step, recipe.steps), recipe_name, step)

--- a/docs/fridge.md
+++ b/docs/fridge.md
@@ -142,3 +142,155 @@ As a rule of thumb, if you want to use prebuilt binaries and upload any of them
 that are not already present, you would use `--fridge`. Cerbero will
 automatically use the ones that exist but build the ones who doesn't, uploading
 them to the fridge if the option is given.
+
+## How to test that fridge works correctly
+
+The easiest way to test fridge is using a local FTP server. The one I use is
+pyftpdlib:
+
+```bash
+pip3 install pyftpdlib
+mkdir -p /tmp/fridge
+python3 -m pyftpdlib -i localhost -d /tmp -w
+```
+
+In `recipes-test` there is a cbc already prepared to work against a local FTP.
+It also provides 4 different test recipes used for the following tests. They do
+not require to bootstrap and all clone the same repo, but at different commits
+if needed:
+
+* test  - has no dependencies
+* test2 - same as test but pointing to different commit
+* test3 - depends on test and test2. It cannot be frozen. Thus, it is always built and no fridge package is ever generated for it
+* test4 - depends on test3
+
+There's a number of edge cases that need to be tested to ensure fridge is
+working correctly. They need to be run in order, because the next one expects
+the status the previous step left:
+
+* Fridge packages can be uploaded. Expected: `upload_binary` steps should run
+  and the /tmp/fridge should have 3 packages: for test, test2 and test4
+
+```bash
+rm -rf /tmp/fridge/**; rm -rf /opt/cerbero-test && ./cerbero-uninstalled -t -c test.cbc build test4 --upload-binaries
+tree -D /tmp/fridge
+```
+
+* Fridge packages can be used. Expected: `fetch_binary` steps should run and only test3
+  should run configure and compile steps
+
+```bash
+rm -rf /opt/cerbero-test && ./cerbero-uninstalled -t -c test.cbc build test4 --use-binaries
+```
+
+* Fridge packages can be generated if they were previously built. Expected:
+  recipes are built from scratch in first command and `upload_binary` is shown
+  in second command, skipping building steps since they were done previously
+
+```bash
+rm -rf /tmp/fridge/**; rm -rf /opt/cerbero-test && ./cerbero-uninstalled -t -c test.cbc build test4
+./cerbero-uninstalled -t -c test.cbc build test4 --upload-binaries
+tree -D /tmp/fridge
+```
+
+* Modifying a recipe changes its checksum, generating a new fridge package.
+  Expected: test4 is reset and built from scratch. Then, it's restored and
+  fetched from fridge
+
+```bash
+echo "# dummy comment" >> recipes-test/test4.recipe
+./cerbero-uninstalled -t -c test.cbc build test4 --fridge
+echo "Restoring and fetching original test4.recipe..."
+content=$(head recipes-test/test4.recipe -n -1)
+echo "$content" > recipes-test/test4.recipe
+./cerbero-uninstalled -t -c test.cbc build test4 --fridge
+tree -D /tmp/fridge
+```
+
+* Modifying a dependency changes the name of both that recipe and all its
+  dependents. Expected: test2 is reset and built from scratch, along with test3
+  and test4. Then, test2 is restored and along with test3 and test4 are fetched
+  from fridge
+
+```bash
+echo "# dummy comment" >> recipes-test/test2.recipe
+./cerbero-uninstalled -t -c test.cbc build test4 --fridge
+tree -D /tmp/fridge
+echo "Restoring and fetching original test2.recipe..."
+content=$(head recipes-test/test2.recipe -n -1)
+echo "$content" > recipes-test/test2.recipe
+./cerbero-uninstalled -t -c test.cbc build test4 --fridge
+tree -D /tmp/fridge
+```
+
+* If a package is not available, recipe is built from scratch as a fallback.
+  Expected: test4 is rebuilt and uploaded
+
+```bash
+rm -rf /tmp/fridge/**/test4* && rm -rf /opt/cerbero-test && ./cerbero-uninstalled -t -c test.cbc build test4 --use-binaries
+./cerbero-uninstalled -t -c test.cbc build test4 --fridge
+tree -D /tmp/fridge
+```
+
+* If a package in fridge does not match the checksum, recipe is built from
+  scratch. Expected: test4 is rebuilt and uploaded
+
+```bash
+echo "1234 1234" > /tmp/fridge/**/test4*.tar.bz2.sha256
+cat /tmp/fridge/**/test4*.tar.bz2.sha256
+rm -rf /opt/cerbero-test && ./cerbero-uninstalled -t -c test.cbc build test4 --fridge
+cat /tmp/fridge/**/test4*.tar.bz2.sha256
+tree -D /tmp/fridge
+```
+
+* If a package in the local cache does not match the checksum, it gets
+  downloaded again. Expected: test4 is uninstalled and test4 is fetched and
+  installed from fridge
+
+```bash
+./cerbero-uninstalled -t -c test.cbc uninstall test4
+tree -D /opt/cerbero-test/binaries
+echo "1234 1234" > /opt/cerbero-test/**/test4*.tar.bz2.sha256
+cat /tmp/fridge/**/test4*.tar.bz2.sha256
+./cerbero-uninstalled -t -c test.cbc build test4 --use-binaries
+cat /tmp/fridge/**/test4*.tar.bz2.sha256
+```
+
+* If a package in fridge is corrupted, recipe is built from scratch. Expected:
+  test4 is built from scratch because `extract_binary` fails
+
+```bash
+file=$(find /tmp/fridge -iname "test4*.tar.bz2")
+dd if=$file count=100 bs=1 of=/tmp/tmp_package.tar.bz2
+cp /tmp/tmp_package.tar.bz2 $file
+sha256sum $file > $file.sha256
+rm -rf /opt/cerbero-test && ./cerbero-uninstalled -t -c test.cbc build test4 --use-binaries
+```
+
+* If a package in local cache is corrupted, recipe is fetched again. Expected:
+  test4 is uninstalled, fetched and installed again
+
+```bash
+file=$(find /opt/cerbero-test/binaries -iname "test4*.tar.bz2")
+dd if=$file count=100 bs=1 of=/tmp/tmp_package.tar.bz2
+cp /tmp/tmp_package.tar.bz2 $file
+sha256sum $file > $file.sha256
+./cerbero-uninstalled -t -c test.cbc uninstall test4
+./cerbero-uninstalled -t -c test.cbc build test4 --use-binaries
+```
+
+* Packages can be fetched from fridge. Expected: `fetch_binary` step runs
+  successfully for test, test2 and test4
+
+```bash
+rm -rf /opt/cerbero-test && ./cerbero-uninstalled -t -c test.cbc fetch test4 --use-binaries
+tree -D /opt/cerbero-test/binaries
+```
+
+* If missing package in fridge, sources are fetched as a fallback. Expected:
+  `fetch_binary` for test4 fails, thus its source is downloaded instead
+
+```bash
+rm -rf /tmp/fridge/**/test4*; rm -rf /opt/cerbero-test && ./cerbero-uninstalled -t -c test.cbc fetch test4 --use-binaries
+tree -D /opt/cerbero-test/binaries && tree -D /opt/cerbero-test/sources/local
+```

--- a/recipes-test/test.recipe
+++ b/recipes-test/test.recipe
@@ -1,0 +1,12 @@
+# -*- Mode: Python -*- vi:si:et:sw=4:sts=4:ts=4:syntax=python
+from cerbero.tools.libtool import LibtoolLibrary
+
+class Recipe(recipe.Recipe):
+    name = 'test'
+    version = '0.10'
+    remotes = {'origin': 'git@bitbucket.org:fluendo/recipe_test.git'}
+    commit = 'origin/master'
+    #library_type = LibraryType.STATIC
+
+    def prepare(self):
+        self.repo_dir = os.path.join(self.config.local_sources, "test")

--- a/recipes-test/test2.recipe
+++ b/recipes-test/test2.recipe
@@ -1,0 +1,14 @@
+# -*- Mode: Python -*- vi:si:et:sw=4:sts=4:ts=4:syntax=python
+from cerbero.tools.libtool import LibtoolLibrary
+
+class Recipe(recipe.Recipe):
+    name = 'test2'
+    version = '0.10'
+    remotes = {'origin': 'git@bitbucket.org:fluendo/recipe_test.git'}
+    #commit = 'origin/master'
+    commit = '910570c0f1178d4ef522b578b58918a437e99b79' # README
+    # commit = 'b01e0e121e5302ed2cd849b2e7c8885efe5efd21' # README-2
+    #library_type = LibraryType.STATIC
+
+    def prepare(self):
+        self.repo_dir = os.path.join(self.config.local_sources, "test")

--- a/recipes-test/test3.recipe
+++ b/recipes-test/test3.recipe
@@ -1,0 +1,14 @@
+# -*- Mode: Python -*- vi:si:et:sw=4:sts=4:ts=4:syntax=python
+from cerbero.tools.libtool import LibtoolLibrary
+
+class Recipe(recipe.Recipe):
+    name = 'test3'
+    version = '0.10'
+    remotes = {'origin': 'git@bitbucket.org:fluendo/recipe_test.git'}
+    commit = 'origin/master'
+    #library_type = LibraryType.STATIC
+    deps = ['test', 'test2']
+    allow_package_creation = False
+
+    def prepare(self):
+        self.repo_dir = os.path.join(self.config.local_sources, "test")

--- a/recipes-test/test4.recipe
+++ b/recipes-test/test4.recipe
@@ -1,0 +1,13 @@
+# -*- Mode: Python -*- vi:si:et:sw=4:sts=4:ts=4:syntax=python
+from cerbero.tools.libtool import LibtoolLibrary
+
+class Recipe(recipe.Recipe):
+    name = 'test4'
+    version = '0.10'
+    remotes = {'origin': 'git@bitbucket.org:fluendo/recipe_test.git'}
+    commit = 'b01e0e121e5302ed2cd849b2e7c8885efe5efd21' # README-2
+    #library_type = LibraryType.STATIC
+    deps = ['test3']
+
+    def prepare(self):
+        self.repo_dir = os.path.join(self.config.local_sources, "test")

--- a/test.cbc
+++ b/test.cbc
@@ -1,0 +1,12 @@
+import os
+from cerbero.build.fridge import FtpBinaryRemote
+
+path = os.path.dirname(os.path.abspath(__file__))
+
+recipes_dir = os.path.join(path, 'recipes-test')
+home_dir = '/opt/cerbero-test'
+# binaries_local = '/opt/cerbero-binaries'
+
+binaries_remote=FtpBinaryRemote('localhost:2121/fridge')
+# binaries_remote=FtpBinaryRemote('officestorage1.fluendo.lan/data/fluendo/tech/public/cerbero-binaries-1.0', 'fluendosys', 'fluendo sys')
+variants += ['static', 'strip', 'va', 'nocdparanoia']


### PR DESCRIPTION
This PR does some heavy and important refactoring to how fridge is implemented.
Before, most of the logic was kept separately within fridge.py on purpose to ease integration with upstream cerbero.
Now, it's completely integrated in the oven so that fridge steps can be considered as any other kind of step. This allows to finally fix the completion percentage:

Before, percentage completely broken once any fridge step was involved:
```
~/Fluendo/fluendo-cerbero on  1.0 [$!?] via 🐍 v2.7.18
13:24:37 ❯ ./cerbero-uninstalled -t -c cerbero/test.cbc build test4 --fridge
0:00:00.001683 Loading default configuration from /home/pablo/.cerbero/cerbero.cbc
0:00:00.007565 WARNING: Variant static is unknown or obsolete
0:00:00.007684 WARNING: Variant va is unknown or obsolete
0:00:00.020446 WARNING: Could not recover status
0:00:00.030071 Building the following recipes: test test2 test3 test4
0:00:00.169221 Fridge initialized with environment hash 6ef8ca9d
0:00:00.169590 [(1/4 @ 0%) test -> fetch_binary]
0:00:01.608071 -----> Downloading fridge binary 6ef8ca9d/test-linux-x86_64-0.10+git~d5611655-09d8993e-devel.tar.bz2
0:00:01.611633 WARNING: Waiting for ('2xx',) but got 550 [' No such file or directory.']
0:00:01.621856 WARNING: No installed files found for recipe 'test'
0:00:01.623893 WARNING: Error unfreezing recipe 'test'. Falling back to build it from scratch
0:00:01.624848 [(1/4 @ 2%) test -> fetch]
0:00:03.311462 [(1/4 @ 5%) test -> extract]
0:00:03.332033 [(1/4 @ 8%) test -> clean_installed_files]
0:00:03.332339 [(1/4 @ 11%) test -> configure]
0:00:04.492232 [(1/4 @ 13%) test -> compile]
0:00:04.501334 [(1/4 @ 16%) test -> install]
0:00:04.513733 [(1/4 @ 19%) test -> post_install]
0:00:04.518407 [(1/4 @ 0%) test -> generate_binary]
0:00:04.525168 [(1/4 @ 0%) test -> upload_binary]
0:00:04.525386 -----> Uploading fridge binary 6ef8ca9d/test-linux-x86_64-0.10+git~d5611655-09d8993e-devel.tar.bz2
0:00:04.533086 [(2/4 @ 25%) test2 -> fetch_binary]
0:00:04.536112 -----> Downloading fridge binary 6ef8ca9d/test2-linux-x86_64-0.10+git~910570c0-ec77f733-devel.tar.bz2
0:00:04.538484 WARNING: Waiting for ('2xx',) but got 550 [' No such file or directory.']
0:00:04.544448 WARNING: No installed files found for recipe 'test2'
0:00:04.544993 WARNING: Error unfreezing recipe 'test2'. Falling back to build it from scratch
0:00:04.545262 [(2/4 @ 27%) test2 -> fetch]
0:00:04.545829 [(2/4 @ 30%) test2 -> extract]
0:00:04.566870 [(2/4 @ 33%) test2 -> clean_installed_files]
0:00:04.567166 [(2/4 @ 36%) test2 -> configure]
0:00:05.729936 [(2/4 @ 38%) test2 -> compile]
0:00:05.733916 [(2/4 @ 41%) test2 -> install]
0:00:05.745198 [(2/4 @ 44%) test2 -> post_install]
0:00:05.750001 [(2/4 @ 25%) test2 -> generate_binary]
0:00:05.756042 [(2/4 @ 25%) test2 -> upload_binary]
0:00:05.756343 -----> Uploading fridge binary 6ef8ca9d/test2-linux-x86_64-0.10+git~910570c0-ec77f733-devel.tar.bz2
0:00:05.765036 Recipe test3 does not allow being unfrozen (allow_package_creation = False)
0:00:05.765103 [(3/4 @ 52%) test3 -> fetch]
0:00:05.765442 [(3/4 @ 55%) test3 -> extract]
0:00:05.784749 [(3/4 @ 58%) test3 -> clean_installed_files]
0:00:05.785095 [(3/4 @ 61%) test3 -> configure]
0:00:06.948578 [(3/4 @ 63%) test3 -> compile]
0:00:06.957969 [(3/4 @ 66%) test3 -> install]
0:00:06.968020 [(3/4 @ 69%) test3 -> post_install]
0:00:06.979028 Recipe test3 does not allow being frozen (allow_package_creation = False)
0:00:06.979979 [(4/4 @ 94%) test4 -> fetch_binary]
0:00:06.983917 -----> Downloading fridge binary 6ef8ca9d/test4-linux-x86_64-0.10+git~b01e0e12-67eb9208-devel.tar.bz2
0:00:06.986282 WARNING: Waiting for ('2xx',) but got 550 [' No such file or directory.']
0:00:06.991186 WARNING: No installed files found for recipe 'test4'
0:00:06.991807 WARNING: Error unfreezing recipe 'test4'. Falling back to build it from scratch
0:00:06.992109 [(4/4 @ 97%) test4 -> fetch]
0:00:06.992788 [(4/4 @ 100%) test4 -> extract]
0:00:07.015578 [(4/4 @ 102%) test4 -> clean_installed_files]
0:00:07.015938 [(4/4 @ 105%) test4 -> configure]
0:00:08.193426 [(4/4 @ 108%) test4 -> compile]
0:00:08.202722 [(4/4 @ 111%) test4 -> install]
0:00:08.214332 [(4/4 @ 113%) test4 -> post_install]
0:00:08.218985 [(4/4 @ 94%) test4 -> generate_binary]
0:00:08.225915 [(4/4 @ 94%) test4 -> upload_binary]
0:00:08.226093 -----> Uploading fridge binary 6ef8ca9d/test4-linux-x86_64-0.10+git~b01e0e12-67eb9208-devel.tar.bz2
```

Now
```
16:26:23 ✗  rm -rf /opt/cerbero-test && ./cerbero-uninstalled -t -c cerbero/test.cbc build test4 --fridge
0:00:00.001781 Loading default configuration from /home/pablo/.cerbero/cerbero.cbc
0:00:00.005619 WARNING: Variant static is unknown or obsolete
0:00:00.005723 WARNING: Variant va is unknown or obsolete
0:00:00.013378 WARNING: Could not recover status
0:00:00.159113 Building the following recipes: test test2 test3 test4
0:00:00.167237 Recipe test3 does not allow being frozen (allow_package_creation = False)
0:00:00.170452 Fridge initialized with environment hash 6ef8ca9d
0:00:01.796750 -----> test2: Remote package '6ef8ca9d/test2-linux-x86_64-0.10+git~910570c0-c14d06c8-devel.tar.bz2' not found. Falling back to fetch from source
0:00:01.809631 -----> test: Remote package '6ef8ca9d/test-linux-x86_64-0.10+git~d5611655-f111c746-devel.tar.bz2' not found. Falling back to fetch from source
0:00:01.823440 -----> test4: Remote package '6ef8ca9d/test4-linux-x86_64-0.10+git~b01e0e12-b4b97ca2-devel.tar.bz2' not found. Falling back to fetch from source
0:00:01.824207 [(1/4 @ 0%) test -> fetch]
0:00:03.726460 [(1/4 @ 2%) test -> extract]
0:00:03.747934 [(1/4 @ 5%) test -> clean_installed_files]
0:00:03.748228 [(1/4 @ 8%) test -> configure]
0:00:04.913140 [(1/4 @ 11%) test -> compile]
0:00:04.917618 [(1/4 @ 13%) test -> install]
0:00:04.931242 [(1/4 @ 16%) test -> post_install]
0:00:04.932011 [(1/4 @ 19%) test -> generate_binary]
0:00:04.944386 [(1/4 @ 22%) test -> upload_binary]
0:00:04.944566 -----> Uploading fridge binary 6ef8ca9d/test-linux-x86_64-0.10+git~d5611655-f111c746-devel.tar.bz2
0:00:04.945625 -----> Uploading environment file to /fridge/6ef8ca9d/ENVIRONMENT
0:00:04.956066 [(2/4 @ 25%) test2 -> fetch]
0:00:04.956940 [(2/4 @ 27%) test2 -> extract]
0:00:04.982189 [(2/4 @ 30%) test2 -> clean_installed_files]
0:00:04.982469 [(2/4 @ 33%) test2 -> configure]
0:00:06.165570 [(2/4 @ 36%) test2 -> compile]
0:00:06.169753 [(2/4 @ 38%) test2 -> install]
0:00:06.182427 [(2/4 @ 41%) test2 -> post_install]
0:00:06.182959 [(2/4 @ 44%) test2 -> generate_binary]
0:00:06.193979 [(2/4 @ 47%) test2 -> upload_binary]
0:00:06.194156 -----> Uploading fridge binary 6ef8ca9d/test2-linux-x86_64-0.10+git~910570c0-c14d06c8-devel.tar.bz2
0:00:06.202978 [(3/4 @ 50%) test3 -> fetch]
0:00:06.203523 [(3/4 @ 53%) test3 -> extract]
0:00:06.230598 [(3/4 @ 57%) test3 -> clean_installed_files]
0:00:06.230933 [(3/4 @ 60%) test3 -> configure]
0:00:07.412767 [(3/4 @ 64%) test3 -> compile]
0:00:07.416837 [(3/4 @ 67%) test3 -> install]
0:00:07.428936 [(3/4 @ 71%) test3 -> post_install]
0:00:07.436662 [(4/4 @ 75%) test4 -> fetch]
0:00:07.437608 [(4/4 @ 77%) test4 -> extract]
0:00:07.464067 [(4/4 @ 80%) test4 -> clean_installed_files]
0:00:07.464410 [(4/4 @ 83%) test4 -> configure]
0:00:08.637916 [(4/4 @ 86%) test4 -> compile]
0:00:08.647197 [(4/4 @ 88%) test4 -> install]
0:00:08.658047 [(4/4 @ 91%) test4 -> post_install]
0:00:08.658864 [(4/4 @ 94%) test4 -> generate_binary]
0:00:08.668840 [(4/4 @ 97%) test4 -> upload_binary]
0:00:08.668998 -----> Uploading fridge binary 6ef8ca9d/test4-linux-x86_64-0.10+git~b01e0e12-b4b97ca2-devel.tar.bz2
0:00:08.681157 [(4/4 @ 100%) All recipes built]
``` 
The easiest way to test fridge is using a local FTP server. The one I use is
pyftpdlib:

```bash
pip3 install pyftpdlib
mkdir -p /tmp/fridge
python3 -m pyftpdlib -i localhost -d /tmp -w
```

In `recipes-test` there is a cbc already prepared to work against a local FTP.
It also provides 4 different test recipes used for the following tests. They do
not require to bootstrap and all clone the same repo, but at different commits
if needed:

* test  - has no dependencies
* test2 - same as test but pointing to different commit
* test3 - depends on test and test2. It cannot be frozen. Thus, it is always built and no fridge package is ever generated for it
* test4 - depends on test3

There's a number of edge cases that need to be tested to ensure fridge is
working correctly. They need to be run in order, because the next one expects
the status the previous step left:

* Fridge packages can be uploaded. Expected: `upload_binary` steps should run
  and the /tmp/fridge should have 3 packages: for test, test2 and test4

```bash
rm -rf /tmp/fridge/*; rm -rf /opt/cerbero-test && ./cerbero-uninstalled -t -c test.cbc build test4 --upload-binaries
tree -hD /tmp/fridge
```

* Fridge packages can be used. Expected: `fetch_binary` steps should run and only test3
  should run configure and compile steps

```bash
rm -rf /opt/cerbero-test && ./cerbero-uninstalled -t -c test.cbc build test4 --use-binaries
```

* Fridge packages can be generated if they were previously built. Expected:
  recipes are built from scratch in first command and `upload_binary` is shown
  in second command, skipping building steps since they were done previously

```bash
rm -rf /tmp/fridge/*; rm -rf /opt/cerbero-test && ./cerbero-uninstalled -t -c test.cbc build test4
./cerbero-uninstalled -t -c test.cbc build test4 --upload-binaries
tree -hD /tmp/fridge
```

* Modifying a recipe changes its checksum, generating a new fridge package.
  Expected: test4 is reset and built from scratch. Then, it's restored and
  fetched from fridge

```bash
echo "# dummy comment" >> recipes-test/test4.recipe
./cerbero-uninstalled -t -c test.cbc build test4 --fridge
echo "Restoring and fetching original test4.recipe..."
content=$(head recipes-test/test4.recipe -n -1)
echo "$content" > recipes-test/test4.recipe
./cerbero-uninstalled -t -c test.cbc build test4 --fridge
tree -hD /tmp/fridge
```

* Modifying a dependency changes the name of both that recipe and all its
  dependents. Expected: test2 is reset and built from scratch, along with test3
  and test4. Then, test2 is restored and along with test3 and test4 are fetched
  from fridge

```bash
echo "# dummy comment" >> recipes-test/test2.recipe
./cerbero-uninstalled -t -c test.cbc build test4 --fridge
tree -hD /tmp/fridge
echo "Restoring and fetching original test2.recipe..."
content=$(head recipes-test/test2.recipe -n -1)
echo "$content" > recipes-test/test2.recipe
./cerbero-uninstalled -t -c test.cbc build test4 --fridge
tree -hD /tmp/fridge
```

* If a package is not available, recipe is built from scratch as a fallback.
  Expected: test4 is rebuilt and uploaded

```bash
rm -rf /tmp/fridge/*/test4* && rm -rf /opt/cerbero-test && ./cerbero-uninstalled -t -c test.cbc build test4 --use-binaries
./cerbero-uninstalled -t -c test.cbc build test4 --fridge
tree -hD /tmp/fridge
```

* If a package in fridge does not match the checksum, recipe is built from
  scratch. Expected: test4 is rebuilt and uploaded

```bash
echo "1234 1234" > /tmp/fridge/*/test4*.tar.bz2.sha256
cat /tmp/fridge/*/test4*.tar.bz2.sha256
rm -rf /opt/cerbero-test && ./cerbero-uninstalled -t -c test.cbc build test4 --fridge
cat /tmp/fridge/*/test4*.tar.bz2.sha256
tree -hD /tmp/fridge
```

* If a package in fridge is corrupted, recipe is built from scratch. Expected:
  test4 is built from scratch because `extract_binary` fails

```bash
file=$(find /tmp/fridge -iname "test4*.tar.bz2")
dd if=$file count=100 bs=1 of=/tmp/tmp_package.tar.bz2
cp /tmp/tmp_package.tar.bz2 $file
sha256sum $file > $file.sha256
rm -rf /opt/cerbero-test && ./cerbero-uninstalled -t -c test.cbc build test4 --fridge
```

* If a package in local cache is corrupted, recipe is fetched again. Expected:
  test4 is uninstalled, fetched and installed again

```bash
file=$(find /opt/cerbero-test/binaries -iname "test4*.tar.bz2")
dd if=$file count=100 bs=1 of=/tmp/tmp_package.tar.bz2
cp /tmp/tmp_package.tar.bz2 $file
sha256sum $file > $file.sha256
./cerbero-uninstalled -t -c test.cbc uninstall test4
tree -hD /opt/cerbero-test/binaries
./cerbero-uninstalled -t -c test.cbc build test4 --use-binaries
tree -hD /opt/cerbero-test/binaries
```

* Packages can be fetched from fridge. Expected: `fetch_binary` step runs
  successfully for test, test2 and test4

```bash
rm -rf /opt/cerbero-test && ./cerbero-uninstalled -t -c test.cbc fetch test4 --use-binaries
tree -hD /opt/cerbero-test/binaries
```

* If missing package in fridge, sources are fetched as a fallback. Expected:
  `fetch_binary` for test fails, thus its source is downloaded instead

```bash
rm -rf /tmp/fridge/*/test-*; rm -rf /opt/cerbero-test && ./cerbero-uninstalled -t -c test.cbc fetch test --use-binaries
tree -hD /opt/cerbero-test/binaries && tree -hD /opt/cerbero-test/sources/local
```