### PR TITLE
OCP-2349 Fix buildone command not working after fridge refactoring

### DIFF
--- a/cerbero/build/fridge.py
+++ b/cerbero/build/fridge.py
@@ -190,11 +190,10 @@ class Fridge (object):
     GEN_BINARY = (N_('Generate Binary'), 'generate_binary')
     UPLOAD_BINARY = (N_('Upload Binary'), 'upload_binary')
 
-    def __init__(self, store, force=False, dry_run=False):
+    def __init__(self, store, dry_run=False):
         self.store = store
         self.cookbook = store.cookbook
         self.config = self.cookbook.get_config()
-        self.force = force
         self.binaries_remote = self.config.binaries_remote
         self.env_checksum = None
         shell.DRY_RUN = dry_run

--- a/cerbero/build/oven.py
+++ b/cerbero/build/oven.py
@@ -109,7 +109,7 @@ class Oven (object):
         # 1. Don't allow creating a package
         # 2. Already run the extract_binary step
         # 3. Have already uploaded the binary to fridge
-        filtered_ordered_recipes = [x for x in ordered_recipes if self.cookbook.recipe_needs_build(x.name) or \
+        filtered_ordered_recipes = [x for x in ordered_recipes if self.force or self.cookbook.recipe_needs_build(x.name) or \
                             (upload_binaries and x.allow_package_creation and not self.cookbook.step_done(x.name, Fridge.EXTRACT_BINARY[1]) \
                             and not self.cookbook.step_done(x.name, Fridge.UPLOAD_BINARY[1]))]
 
@@ -125,7 +125,7 @@ class Oven (object):
         fridge = None
         if use_binaries or upload_binaries:
             fridge = Fridge(PackagesStore(self.config, recipes=ordered_recipes, cookbook=self.cookbook),
-                            force=self.force, dry_run=shell.DRY_RUN)
+                            dry_run=shell.DRY_RUN)
 
         self._build_status_printer = BuildStatusPrinter()
         self._build_status_printer.total = length
@@ -224,7 +224,7 @@ class Oven (object):
                 # relocated
                 # WARNING: the method to automatically detect files will only
                 # work when installing recipes not concurrently
-                if self.cookbook.recipe_needs_build(recipe.name) and \
+                if (self.force or self.cookbook.recipe_needs_build(recipe.name)) and \
                     step in [BuildSteps.RELOCATE_OSX_LIBRARIES[1], Fridge.GEN_BINARY[1]]:
                     self._update_installed_files(recipe, tmp)
 

--- a/docs/fridge.md
+++ b/docs/fridge.md
@@ -176,8 +176,8 @@ rm -rf /tmp/fridge/*; rm -rf /opt/cerbero-test && ./cerbero-uninstalled -t -c te
 tree -hD /tmp/fridge
 ```
 
-* Fridge packages can be used. Expected: `fetch_binary` steps should run and only test3
-  should run configure and compile steps
+* Fridge packages can be used. Expected: `fetch_binary` and `extract_binary`
+  steps should run and only test3 should run configure and compile steps
 
 ```bash
 rm -rf /opt/cerbero-test && ./cerbero-uninstalled -t -c test.cbc build test4 --use-binaries
@@ -191,6 +191,28 @@ rm -rf /opt/cerbero-test && ./cerbero-uninstalled -t -c test.cbc build test4 --u
 rm -rf /tmp/fridge/*; rm -rf /opt/cerbero-test && ./cerbero-uninstalled -t -c test.cbc build test4
 ./cerbero-uninstalled -t -c test.cbc build test4 --upload-binaries
 tree -hD /tmp/fridge
+```
+
+* buildone command forces a rebuild of the recipe. Expected: only test4 is
+  built from scratch
+
+```bash
+./cerbero-uninstalled -t -c test.cbc buildone test4
+```
+
+* Fridge with buildone command forces a rebuild of the recipe, uploading the
+  binaries. Expected: only test4 is built from scratch and `upload_binary` step
+  is executed
+
+```bash
+./cerbero-uninstalled -t -c test.cbc buildone test4 --upload-binaries
+```
+
+* Fridge with buildone command forces a rebuild of the recipe, fetching the binaries. Expected: only
+  test4 recipe runs `fetch_binary` and `extract_binary` steps:
+
+```bash
+./cerbero-uninstalled -t -c test.cbc buildone test4 --use-binaries
 ```
 
 * Modifying a recipe changes its checksum, generating a new fridge package.


### PR DESCRIPTION
4240234c4b0d36dfa0df79fd5d415e7d2f11db72 refactoring of
fridge introduced this subtle but important bug.

TL;DR I forgot to check for the `force` parameter in two
different places when micro-optimizing two paths.