### PR TITLE
OCP-2383 Optional lists of conflicting, provided and replaced packages

### DIFF
--- a/cerbero/commands/package.py
+++ b/cerbero/commands/package.py
@@ -111,8 +111,6 @@ class Package(Command):
             pkg = Packager(config, p, self.store)
         m.action(_("Creating package for %s") % p.name)
         output_dir = os.path.abspath(args.output_dir)
-        if args.no_split:
-            args.no_devel = False
         paths = pkg.pack(output_dir, args.no_devel,
                          args.force, args.keep_temp,
                          not args.no_split)

--- a/cerbero/packages/package.py
+++ b/cerbero/packages/package.py
@@ -22,7 +22,7 @@ import hashlib
 import inspect
 
 from cerbero.build.filesprovider import FilesProvider
-from cerbero.enums import License, Platform
+from cerbero.enums import License, Platform, Distro
 from cerbero.packages import PackageType
 from cerbero.utils import remove_list_duplicates, get_class_checksum, messages as m
 
@@ -90,6 +90,12 @@ class PackageBase(object):
     @type strip: list
     @cvar strip_excludes: files that won't be stripped
     @type strip_excludes: list
+    @cvar provides = list of packages which functionality is provided
+    @type provides = dict
+    @cvar conflicts = list of conflicting packages
+    @type conflicts = dict
+    @cvar replaces_obsoletes = list of replaced/obsoleted packages
+    @type replaces_obsoletes = dict
     '''
     name = 'default'
     shortdesc = 'default'
@@ -120,6 +126,12 @@ class PackageBase(object):
     strip = False
     strip_dirs = ['bin']
     strip_excludes = []
+    provides = {Distro.DEBIAN: {PackageType.RUNTIME: [], PackageType.DEVEL: []},
+                Distro.REDHAT: {PackageType.RUNTIME: [], PackageType.DEVEL: []}}
+    conflicts = {Distro.DEBIAN: {PackageType.RUNTIME: [], PackageType.DEVEL: []},
+                 Distro.REDHAT: {PackageType.RUNTIME: [], PackageType.DEVEL: []}}
+    replaces_obsoletes = {Distro.DEBIAN: {PackageType.RUNTIME: [], PackageType.DEVEL: []},
+                          Distro.REDHAT: {PackageType.RUNTIME: [], PackageType.DEVEL: []}}
 
     def __init__(self, config, store):
         self.config = config


### PR DESCRIPTION
Added set of variables to hold lists of packages that are:
- provided by the package
- conflicting with it
- replaces or obsoleted by the package.

These values will be set to corresponding tags when creating a Debian
or Redhat package.

More information about 'Provides', 'Conflicts' and
'Replaces'/'Obsoletes' tags:
https://www.debian.org/doc/debian-policy/ch-relationships.html
https://rpm.org/user_doc/dependencies.html