### PR TITLE
utils: configure wget to retry correctly

### DIFF
--- a/cerbero/utils/shell.py
+++ b/cerbero/utils/shell.py
@@ -364,16 +364,19 @@ async def download_wget(url, destination=None, check_cert=True, overwrite=False,
         if password:
             cmd += " --password \"%s\"" % password
 
-    cmd += " --tries=2 --retry-connrefused --retry-on-host-error --retry-on-http-error=404,429,503,504"
     cmd += " --timeout=10.0"
     cmd += " --progress=dot:giga"
 
-    try:
-        await async_call(cmd, path, logfile=logfile)
-    except FatalError as e:
-        if os.path.exists(destination):
-            os.remove(destination)
-        raise e
+    tries = 2
+    while True:
+        try:
+            return await async_call(cmd, path, logfile=logfile)
+        except FatalError as e:
+            tries -= 1
+            if os.path.exists(destination):
+                os.remove(destination)
+            if tries == 0:
+                raise e
 
 
 async def download_urllib2(url, destination=None, check_cert=True, overwrite=False, logfile=None, user=None, password=None):


### PR DESCRIPTION
The `retry-connrefused`, 'retry-on-host-error' and
`retry-on-http-error` options are mandatory to retry correctly, only
with the`tries` option is not enough.

Before:
```
$ wget http://httpbin.org/status/404 --tries=4 --timeout=10.0 --progress=dot:giga
--2021-10-08 11:47:22--  http://httpbin.org/status/404
Resolving httpbin.org (httpbin.org)... 3.209.149.47, 54.156.165.4, 54.159.86.231, ...
Connecting to httpbin.org (httpbin.org)|3.209.149.47|:80... connected.
HTTP request sent, awaiting response... 404 NOT FOUND
2021-10-08 11:47:22 ERROR 404: NOT FOUND.
```

After:
```
$ wget http://httpbin.org/status/404 --tries=4 --retry-connrefused --retry-on-host-error --retry-on-http-error=404,429,503,504 --timeout=10.0 --progress=dot:giga
--2021-10-08 11:48:10--  http://httpbin.org/status/404
Resolving httpbin.org (httpbin.org)... 3.215.162.201, 54.159.86.231, 54.156.165.4, ...
Connecting to httpbin.org (httpbin.org)|3.215.162.201|:80... connected.
HTTP request sent, awaiting response... 404 NOT FOUND
Retrying.

--2021-10-08 11:48:12--  (try: 2)  http://httpbin.org/status/404
Reusing existing connection to httpbin.org:80.
HTTP request sent, awaiting response... 404 NOT FOUND
Retrying.

--2021-10-08 11:48:14--  (try: 3)  http://httpbin.org/status/404
Reusing existing connection to httpbin.org:80.
HTTP request sent, awaiting response... 404 NOT FOUND
Retrying.

--2021-10-08 11:48:17--  (try: 4)  http://httpbin.org/status/404
Reusing existing connection to httpbin.org:80.
HTTP request sent, awaiting response... 404 NOT FOUND
Giving up.
```