### PR TITLE
source: fix Git extraction path for CMake recipes

### DIFF
--- a/cerbero/build/source.py
+++ b/cerbero/build/source.py
@@ -59,6 +59,7 @@ class Source (object):
     offline = False
 
     def __init__(self):
+        self.config_src_dir = self.build_dir
         if self.patches is None:
             self.patches = []
 
@@ -489,29 +490,29 @@ class Git (GitCache):
             fetch_done.notify_all()
 
     async def extract(self):
-        if os.path.exists(self.build_dir):
+        if os.path.exists(self.config_src_dir):
             try:
                 commit_hash = git.get_hash(self.config, self.repo_dir, self.commit)
-                checkout_hash = git.get_hash(self.config, self.build_dir, 'HEAD')
+                checkout_hash = git.get_hash(self.config, self.config_src_dir, 'HEAD')
                 if commit_hash == checkout_hash and not self.patches:
                     return False
             except Exception:
                 pass
-            shutil.rmtree(self.build_dir)
-        if not os.path.exists(self.build_dir):
-            os.mkdir(self.build_dir)
+            shutil.rmtree(self.config_src_dir)
+        if not os.path.exists(self.config_src_dir):
+            os.makedirs(self.config_src_dir)
 
         # checkout the current version
-        await git.local_checkout(self.build_dir, self.repo_dir, self.commit, logfile=get_logfile(self))
+        await git.local_checkout(self.config_src_dir, self.repo_dir, self.commit, logfile=get_logfile(self))
 
         for patch in self.patches:
             if not os.path.isabs(patch):
                 patch = self.relative_path(patch)
 
             if self.strip == 1:
-                git.apply_patch(patch, self.build_dir, logfile=get_logfile(self))
+                git.apply_patch(patch, self.config_src_dir, logfile=get_logfile(self))
             else:
-                shell.apply_patch(patch, self.build_dir, self.strip, logfile=get_logfile(self))
+                shell.apply_patch(patch, self.config_src_dir, self.strip, logfile=get_logfile(self))
 
         return True
 
@@ -538,9 +539,9 @@ class GitExtractedTarball(Git):
             return False
         for match in self.matches:
             self._files[match] = []
-        self._find_files(self.build_dir)
+        self._find_files(self.config_src_dir)
         self._files['.in'] = [x for x in self._files['.in'] if
-                os.path.join(self.build_dir, 'm4') not in x]
+                os.path.join(self.config_src_dir, 'm4') not in x]
         self._fix_ts()
 
     def _fix_ts(self):

--- a/recipes/glib.recipe
+++ b/recipes/glib.recipe
@@ -49,6 +49,7 @@ class Recipe(recipe.Recipe):
                # https://gitlab.gnome.org/GNOME/glib/merge_requests/187
                #'glib/0001-meson-use-the-new-python-module-instead-of-the-pytho.patch',
                'glib/0001-Make-it-compile-for-Android-API-18.patch',
+               'glib/0001-meson-Define-__GCC_HAVE_SYNC_COMPARE_AND_SWAP_4-on-G.patch',
               ]
 
     files_libs = [

--- a/recipes/glib/0001-meson-Define-__GCC_HAVE_SYNC_COMPARE_AND_SWAP_4-on-G.patch
+++ b/recipes/glib/0001-meson-Define-__GCC_HAVE_SYNC_COMPARE_AND_SWAP_4-on-G.patch
@@ -1,0 +1,54 @@
+From 4e058a698afdf892f1ee2692a4b818e4ded03570 Mon Sep 17 00:00:00 2001
+From: Simon McVittie <smcv@collabora.com>
+Date: Tue, 30 Oct 2018 17:20:34 +0000
+Subject: [PATCH] meson: Define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 on GNU/Linux
+ if needed
+
+armv5 Linux systems implement __sync_bool_compare_and_swap() and
+friends by calling a function provided by the kernel. This is not
+technically an atomic intrinsic, so gcc doesn't define
+__GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 in this case, but it's good
+enough for us. Extend the current Android special case to cover
+GNU/Linux too.
+
+The possibilities are:
+
+* __sync_foo detected and __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 predefined:
+  calls to __atomic_foo or __sync_foo primitives are inlined into user
+  code by gatomic.h
+
+* __sync_foo detected but __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 not
+  predefined: user code has an extern reference to g_atomic_foo(),
+  which calls __atomic_foo or __sync_foo because we defined
+  __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 when compiling GLib itself
+
+* Windows: user code has an extern reference to g_atomic_foo(),
+  which calls InterlockedFoo()
+
+* !defined(G_ATOMIC_LOCK_FREE): user code has an extern reference to
+  g_atomic_foo(), which emulates atomic operations with a mutex
+
+Signed-off-by: Simon McVittie <smcv@collabora.com>
+Closes: #1576
+---
+ meson.build | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index e642ae227..3af08f866 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1575,8 +1575,8 @@ atomicdefine = '''
+ # We know that we can always use real ("lock free") atomic operations with MSVC
+ if cc.get_id() == 'msvc' or cc.links(atomictest, name : 'atomic ops')
+   have_atomic_lock_free = true
+-  if host_system == 'android' and not cc.compiles(atomicdefine, name : 'atomic ops define')
+-    # When building for armv5 on Android, gcc 4.9 provides
++  if (host_system == 'android' or host_system == 'linux') and not cc.compiles(atomicdefine, name : 'atomic ops define')
++    # When building for armv5 on Linux, gcc provides
+     # __sync_bool_compare_and_swap but doesn't define
+     # __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4
+     glib_conf.set('__GCC_HAVE_SYNC_COMPARE_AND_SWAP_4', true)
+-- 
+2.35.1
+


### PR DESCRIPTION
When trying to build a recipe that uses both git and CMake, the following error message is shown:
CMake Error: The source directory "/home/jorge/cerbero/sources/android_universal/armv7/my-package-1.2" does not appear to contain CMakeLists.txt.

When using CMake:
self.build_dir == ARCH/PACKAGE-VERSION/_builddir (Path where Git extracts sources)
and
self.config_src_dir == ARCH/PACKAGE-VERSION (Path where Git should extract sources)

The problem is that Git class "extracts" sources to self.build_dir.
build_dir is the path to put binaries (as explained in the message of commit 2d520bfd)

Sources have to be extracted to self.config.sources:
- Tarball Class extracts the sources to self.config.sources.
- self.config.sources is also the path where patches are applied.

Note: Cherry-picked by cfalgueras@fluendo.com <Carlos Falgueras García>
Part-of: <https://gitlab.freedesktop.org/gstreamer/cerbero/-/merge_requests/700>