### PR TITLE
git: Fix issue with last security patch

### DIFF
--- a/cerbero/utils/shell.py
+++ b/cerbero/utils/shell.py
@@ -330,7 +330,7 @@ async def unpack(filepath, output_dir, logfile=None):
         if PLATFORM != Platform.WINDOWS:
             if not os.path.exists(output_dir):
                 os.makedirs(output_dir)
-            await async_call(['tar', '-C', output_dir, '-xf', filepath])
+            await async_call(['tar', '-C', output_dir, '-xf', filepath, '--no-same-owner'])
         else:
             cmode = 'bz2' if filepath.endswith('bz2') else filepath[-2:]
             tf = tarfile.open(filepath, mode='r:' + cmode)


### PR DESCRIPTION
Error:

```
$ tar xvf automake-1.15.1.tar.xz
$ cd automake-1.15.1
$ ls -l
total 1520
-rw-r--r-- 1 jenkins jenkins   1516 Jun 18  2017 aclocal.m4
-rw-r--r-- 1 jenkins jenkins    553 Dec 20  2015 AUTHORS
drwxrwxr-x 2 jenkins jenkins   4096 Jun 19  2017 bin
-rwxrwxr-x 1 jenkins jenkins   3995 Jun 17  2017 bootstrap
-r--r--r-- 1 jenkins jenkins 816626 Jun 19  2017 ChangeLog
-rwxrwxr-x 1 jenkins jenkins 232853 Jun 18  2017 configure
-rw-rw-r-- 1 jenkins jenkins  22833 Jun 18  2017 configure.ac
drwxrwxr-x 4 jenkins jenkins   4096 Jun 19  2017 contrib
-rw-rw-r-- 1 jenkins jenkins  17987 Jun 17  2017 COPYING
drwxrwxr-x 3 jenkins jenkins   4096 Jun 19  2017 doc
-rwxrwxr-x 1 jenkins jenkins  13940 Jun 16  2017 gen-testsuite-part
-rw-rw-r-- 1 jenkins jenkins   3300 Jun 16  2017 GNUmakefile
-rw-rw-r-- 1 jenkins jenkins  17844 Jun 18  2017 HACKING
-rw-rw-r-- 1 jenkins jenkins  15752 Jun 17  2017 INSTALL
drwxrwxr-x 4 jenkins jenkins   4096 Jun 19  2017 lib
drwxrwxr-x 4 jenkins jenkins   4096 Jun 19  2017 m4
drwxrwxr-x 2 jenkins jenkins   4096 Jun 19  2017 maintainer
-rw-rw-r-- 1 jenkins jenkins   4278 Jun 16  2017 Makefile.am
-rw-r--r-- 1 jenkins jenkins 133420 Jun 18  2017 Makefile.in
-rw-rw-r-- 1 jenkins jenkins 124401 Jun 18  2017 NEWS
drwxrwxr-x 2 jenkins jenkins   4096 Jun 19  2017 old
drwxr-xr-x 4 jenkins jenkins   4096 Jun 17  2017 PLANS
-rw-rw-r-- 1 jenkins jenkins   2713 Jun 17  2017 README
drwxrwxr-x 6 jenkins jenkins  53248 Jun 19  2017 t
-rw-rw-r-- 1 jenkins jenkins  22998 Jun 17  2017 THANKS
$ git init
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint:   git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint:   git branch -m <name>
Initialized empty Git repository in /tmp/a/automake-1.15.1/.git/
$ git status
fatal: unsafe repository ('/tmp/a/automake-1.15.1' is owned by someone else)
To add an exception for this directory, call:

        git config --global --add safe.directory /tmp/a/automake-1.15.1
$ git config user.email "cerbero@gstreamer.freedesktop.org"
fatal: not in a git directory
```

Related to:
https://stackoverflow.com/questions/71849415/cannot-add-parent-directory-to-safe-directory-on-git
and
https://github.blog/2022-04-12-git-security-vulnerability-announced/

Solution is using `--no-same-owner` to extract files as yourself.