### PR TITLE
source: Fetch Git recipes in case of buildone

### DIFF
--- a/cerbero/build/source.py
+++ b/cerbero/build/source.py
@@ -442,7 +442,7 @@ class Git (GitCache):
             # If we used cookbook.step_done, we'd be creating a new status
             # for those recipes that don't exist yet, introducing overhead.
             status = self.config.cookbook.status.get(recipe.name)
-            if status and 'fetch' in status.steps and not recipe.force:
+            if status and 'fetch' in status.steps and not self.force:
                 return True
         return False
 


### PR DESCRIPTION
The buildone command sets Oven.force to True and the Oven object
sets Oven.recipe to Oven.force value.

In the Git class, if Git.force is True, then the git repository
should be always fetched.

Issue: OCP_3227