### PR TITLE
osxrelocator: Provide object_file to is_mach_o_file in change_id

### DIFF
--- a/cerbero/tools/osxrelocator.py
+++ b/cerbero/tools/osxrelocator.py
@@ -55,7 +55,7 @@ class OSXRelocator(object):
     def change_id(self, object_file, id=None):
         id = id or object_file.replace(self.lib_prefix, '@rpath')
         filename = os.path.basename(object_file)
-        if not self.is_mach_o_file(filename):
+        if not self.is_mach_o_file(object_file):
             return
         cmd = '%s -id "%s" "%s"' % (INT_CMD, id, object_file)
         shell.call(cmd, fail=False, logfile=self.logfile)


### PR DESCRIPTION
When sending filename instead of object_file, i.e. full path to file, the command 'file -bh filename' is not able to find the find the file. Therefore, the function will return False always that fileext is different than '.dylib'.

Issue: OCP_3452