### PR TITLE
OCP-3623 linux: Avoid AC_TRY_RUN calls when cross-compiling for ARM64

### DIFF
--- a/config/linux.config
+++ b/config/linux.config
@@ -32,7 +32,7 @@ if target_arch == Architecture.X86:
 elif target_arch == Architecture.X86_64:
     arch_flags += ' -m64 '
     _host = 'x86_64-linux-gnu'
-if target_arch in [Architecture.ARM, Architecture.ARMv7]:
+if target_arch in [Architecture.ARM, Architecture.ARMv7, Architecture.ARM64]:
     if target_arch == Architecture.ARMv7:
        arch_flags += ' -march=armv7-a '
     if distro == Distro.REDHAT:


### PR DESCRIPTION
Issue: OCP_3623