### PR TITLE
linux.config: Fix gstreamer cross compilation

### DIFF
--- a/config/linux.config
+++ b/config/linux.config
@@ -45,6 +45,7 @@ if target_arch in [Architecture.ARM, Architecture.ARMv7, Architecture.ARM64]:
     os.environ['ac_cv_func_posix_getpwuid_r'] = 'yes'
     os.environ['ac_cv_func_register_printf_specifier'] = 'no'
     os.environ['ac_cv_func_register_printf_function'] = 'no'
+    os.environ['as_cv_unaligned_access'] = 'no'
 
 if target_arch_flags is not None:
     arch_flags += ' %s ' % (target_arch_flags)


### PR DESCRIPTION
GStreamer configure.ac uses a test program for check if unaligned access is possible. The safer or more conservative value for this is zero because it's been used for set the macro `GST_HAVE_UNALIGNED_ACCESS` which chooses between faster and slower implementations for read/swap integers from a memory buffer.

Issue: OCP_3624