### PR TITLE
Fix ambigous argument on git rev-parse

### DIFF
--- a/cerbero/utils/git.py
+++ b/cerbero/utils/git.py
@@ -233,7 +233,7 @@ async def async_get_hash(config, git_dir, commit, remotes=None):
                 return commit
         else:
             raise Exception('Cannot retrieve hash of a commit without cloning or knowing the remote')
-    output = await shell.async_check_output('%s rev-parse %s' %
+    output = await shell.async_check_output('%s rev-parse -- %s' %
                             (GIT, commit), git_dir, env=env)
     return output.rstrip()
 


### PR DESCRIPTION
Experienced this issue on Ubuntu Jammy
```
forccon@forccon-fluendo:~/checkout/fluendo/fluendo-cerbero$ ./cerbero-uninstalled -c projects/codecs/1.20/native.cbc build --use-binaries gst-fluendo-hwvah264dec-1.0
Loading default configuration from /home/forccon/.cerbero/cerbero.cbc
WARNING: Variant elf is unknown or obsolete
WARNING: git remote origin URL 'ssh://git@github.com/libffi/libffi.git' uses 'ssh', please only use this for testing
Building the following recipes: ipp libffi zlib glib libunwind gstreamer-1.0 libogg libpng pixman expat bzip2 freetype fontconfig cairo fribidi harfbuzz pango libvorbis libtheora orc opus graphene libjpeg-turbo cdparanoia gst-plugins-base-1.0 openssl curl gst-fluendo-hwvah264dec-1.0
Recipe ipp does not allow being frozen (allow_package_creation = False)
Fridge initialized with environment hash 28f753d4
-----> libogg: Remote package '28f753d4/libogg-linux-x86_64-1.3.3-99da51d9-devel.tar.bz2' not found. Falling back to fetch from source
-----> zlib: Remote package '28f753d4/zlib-linux-x86_64-1.2.11-1b627d8c-devel.tar.bz2' not found. Falling back to fetch from source
-----> libpng: Remote package '28f753d4/libpng-linux-x86_64-1.6.35-29be9e7a-devel.tar.bz2' not found. Falling back to fetch from source
-----> gstreamer-1.0: Remote package '28f753d4/gstreamer-1.0-linux-x86_64-1.20.1-4d9f86ba-devel.tar.bz2' not found. Falling back to fetch from source
-----> glib: Remote package '28f753d4/glib-linux-x86_64-2.58.0-b014e3cf-devel.tar.bz2' not found. Falling back to fetch from source
-----> pixman: Remote package '28f753d4/pixman-linux-x86_64-0.34.0-28e60065-devel.tar.bz2' not found. Falling back to fetch from source
-----> libunwind: Remote package '28f753d4/libunwind-linux-x86_64-1.3.1-36c368b4-devel.tar.bz2' not found. Falling back to fetch from source
-----> freetype: Remote package '28f753d4/freetype-linux-x86_64-2.9-3db4bacc-devel.tar.bz2' not found. Falling back to fetch from source
-----> expat: Remote package '28f753d4/expat-linux-x86_64-2.2.5-c6dbed7a-devel.tar.bz2' not found. Falling back to fetch from source
-----> bzip2: Remote package '28f753d4/bzip2-linux-x86_64-1.0.6-25dc7a59-devel.tar.bz2' not found. Falling back to fetch from source
-----> fontconfig: Remote package '28f753d4/fontconfig-linux-x86_64-2.12.6-224cdef8-devel.tar.bz2' not found. Falling back to fetch from source
-----> cairo: Remote package '28f753d4/cairo-linux-x86_64-1.14.12-2ebb7c49-devel.tar.bz2' not found. Falling back to fetch from source
-----> libffi: Remote package '28f753d4/libffi-linux-x86_64-3.2.9999+git~f0215d17-cfc9652a-devel.tar.bz2' not found. Falling back to fetch from source
-----> fribidi: Remote package '28f753d4/fribidi-linux-x86_64-1.0.5-f8e0369b-devel.tar.bz2' not found. Falling back to fetch from source
-----> harfbuzz: Remote package '28f753d4/harfbuzz-linux-x86_64-1.7.5-d35d2c5d-devel.tar.bz2' not found. Falling back to fetch from source
-----> libtheora: Remote package '28f753d4/libtheora-linux-x86_64-1.1.1-e9cd8e2e-devel.tar.bz2' not found. Falling back to fetch from source
-----> libvorbis: Remote package '28f753d4/libvorbis-linux-x86_64-1.3.6-24c84303-devel.tar.bz2' not found. Falling back to fetch from source
-----> graphene: Remote package '28f753d4/graphene-linux-x86_64-1.8.2-d67def0c-devel.tar.bz2' not found. Falling back to fetch from source
-----> opus: Remote package '28f753d4/opus-linux-x86_64-1.3-ba53e6cf-devel.tar.bz2' not found. Falling back to fetch from source
fatal: ambiguous argument 'origin/master': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
WARNING: Error checking if recipe gst-fluendo-hwvah264dec-1.0 exists in remote: Fatal Error: Running ['sh', '-c', 'git rev-parse origin/master'], returncode 128:
origin/master

Traceback (most recent call last):
  File "/home/forccon/checkout/fluendo/fluendo-cerbero/./cerbero/cerbero/build/fridge.py", line 213, in check_remote_binary_exists
    await recipe.async_built_version()
  File "/home/forccon/checkout/fluendo/fluendo-cerbero/./cerbero/cerbero/build/source.py", line 341, in async_built_version
    git_hash = await git.async_get_hash(self.config, self.repo_dir, self.commit, self.remotes)
  File "/home/forccon/checkout/fluendo/fluendo-cerbero/./cerbero/cerbero/utils/git.py", line 236, in async_get_hash
    output = await shell.async_check_output('%s rev-parse %s' %
  File "/home/forccon/checkout/fluendo/fluendo-cerbero/./cerbero/cerbero/utils/shell.py", line 296, in async_check_output
    raise FatalError('Running {!r}, returncode {}:\n{}'.format(cmd, proc.returncode, output))
cerbero.errors.FatalError: Fatal Error: Running ['sh', '-c', 'git rev-parse origin/master'], returncode 128:
origin/master


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/forccon/checkout/fluendo/fluendo-cerbero/./cerbero-uninstalled", line 14, in <module>
    main()
  File "/home/forccon/checkout/fluendo/fluendo-cerbero/./cerbero/cerbero/main.py", line 204, in main
    Main(sys.argv[1:])
  File "/home/forccon/checkout/fluendo/fluendo-cerbero/./cerbero/cerbero/main.py", line 66, in __init__
    self.run_command()
  File "/home/forccon/checkout/fluendo/fluendo-cerbero/./cerbero/cerbero/main.py", line 173, in run_command
    res = commands.run(command, self.config, self.args)
  File "/home/forccon/checkout/fluendo/fluendo-cerbero/./cerbero/cerbero/commands/__init__.py", line 78, in run
    return _commands[command].run(config, args)
  File "/home/forccon/checkout/fluendo/fluendo-cerbero/./cerbero/cerbero/commands/build.py", line 79, in run
    self.runargs(config, args.recipe, args.missing_files, self.force,
  File "/home/forccon/checkout/fluendo/fluendo-cerbero/./cerbero/cerbero/commands/build.py", line 92, in runargs
    oven.start_cooking(use_binaries, upload_binaries)
  File "/home/forccon/checkout/fluendo/fluendo-cerbero/./cerbero/cerbero/build/oven.py", line 153, in start_cooking
    run_until_complete(tasks)
  File "/home/forccon/checkout/fluendo/fluendo-cerbero/./cerbero/cerbero/utils/__init__.py", line 684, in run_until_complete
    result = loop.run_until_complete(asyncio.gather(*worker_tasks))
  File "/usr/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/home/forccon/checkout/fluendo/fluendo-cerbero/./cerbero/cerbero/utils/__init__.py", line 680, in _worker
    await task
  File "/home/forccon/checkout/fluendo/fluendo-cerbero/./cerbero/cerbero/build/oven.py", line 143, in _add_fridge_steps_if_needed
    await fridge.check_remote_binary_exists(recipe)
  File "/home/forccon/checkout/fluendo/fluendo-cerbero/./cerbero/cerbero/build/fridge.py", line 223, in check_remote_binary_exists
    raise PackageNotFoundError(os.path.join(self.env_checksum, package_name))
UnboundLocalError: local variable 'package_name' referenced before assignment
```