### PR TITLE
﻿Modern Gentoo distr adaptation

### DIFF
--- a/cerbero/utils/__init__.py
+++ b/cerbero/utils/__init__.py
@@ -326,7 +326,7 @@ Terminating.''', file=sys.stderr)
         elif d[0].strip() in ['arch', 'Arch Linux']:
             distro = Distro.ARCH
             distro_version = DistroVersion.ARCH_ROLLING
-        elif d[0].strip() in ['Gentoo Base System']:
+        elif d[0].strip() in ['Gentoo Base System', 'Gentoo']:
             distro = Distro.GENTOO
             distro_version = DistroVersion.GENTOO_VERSION
         else:


### PR DESCRIPTION
Otherwise:

      File "..../cerbero/cerbero/utils/__init__.py", line 333, in system_info
        raise FatalError("Distribution '%s' not supported" % str(d))
    cerbero.errors.FatalError: Fatal Error: Distribution '('Gentoo', '2.9', 'n/a')' not supported
