### PR TITLE
﻿Forgotten current directory for git config command (name&email).

### DIFF
--- a/cerbero/utils/git.py
+++ b/cerbero/utils/git.py
@@ -32,13 +32,13 @@ def ensure_user_is_set(git_dir, logfile=None):
     # Set the user configuration for this repository so that Cerbero never warns
     # about it or errors out (it errors out with git-for-windows)
     try:
-        shell.call('%s config user.email' % GIT, logfile=logfile)
+        shell.call('%s config user.email' % GIT, git_dir, logfile=logfile)
     except FatalError:
         shell.call('%s config user.email "cerbero@gstreamer.freedesktop.org"' %
                    GIT, git_dir, logfile=logfile)
 
     try:
-        shell.call('%s config user.name' % GIT, logfile=logfile)
+        shell.call('%s config user.name' % GIT, git_dir, logfile=logfile)
     except FatalError:
         shell.call('%s config user.name "Cerbero Build System"' %
                    GIT, git_dir, logfile=logfile)

--- a/cerbero/utils/git.py
+++ b/cerbero/utils/git.py
@@ -29,8 +29,9 @@ GIT = 'git'
 
 
 def ensure_user_is_set(git_dir, logfile=None):
-    # Set the user configuration for this repository so that Cerbero never warns
-    # about it or errors out (it errors out with git-for-windows)
+    # Set the user configuration for this repository
+    # so that commands that need the account's default identity
+    # (e.g., git commit), will not fail.
     try:
         shell.call('%s config user.email' % GIT, git_dir, logfile=logfile)
     except FatalError:


### PR DESCRIPTION
In `cerbero.utils.git.ensure_user_is_set()`: forgotten git_dir argument for checking the existence of account's default identity (user.{email,name}).

As a result the check was performed on the build current directory (‘.’).

For example, I had problems with bootstrap stage for "libtool -> extract":
```
[(4/15 @ 25%) automake -> post_install]
[(5/15 @ 26%) libtool -> fetch]
[(5/15 @ 27%) libtool -> extract]
-----> Extracting tarball to /home/maxatka/Fluendo/fluendo-cerbero/my_build_dir/fluendo-codecs-1.20-linux-x86_64/sources/build-tools/libtool-2.4.6
Unpacking /home/maxatka/Fluendo/fluendo-cerbero/my_build_dir/fluendo-codecs-1.20-linux-x86_64/sources/local/libtool-2.4.6/libtool-2.4.6.tar.xz in /home/maxatka/Fluendo/fluendo-cerbero/my_build_dir/fluendo-codecs-1.20-linux-x86_64/sources/build-tools
Running command 'git init'
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint: 
hint: 	git config --global init.defaultBranch <name>
hint: 
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint: 
hint: 	git branch -m <name>
Initialized empty Git repository in /home/maxatka/Fluendo/fluendo-cerbero/my_build_dir/fluendo-codecs-1.20-linux-x86_64/sources/build-tools/libtool-2.4.6/.git/
Running command 'git config user.email'
mdementyev@fluendo.com
Running command 'git config user.name'
Maxim P. DEMENTYEV
Running command 'git add --force -A .'
Running command 'git commit -m "Initial commit" > /dev/null 2>&1'
Running command 'git am --ignore-whitespace /home/maxatka/Fluendo/fluendo-cerbero/cerbero/recipes/build-tools/libtool/0001-Add-support-for-weak_framework-linking-on-Darwin.patch'
Committer identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'maxatka@max-notebook.(none)')

Recipe 'libtool' failed at the build step 'extract'
Select an action to proceed:
[0] Enter the shell
[1] Rebuild the recipe from scratch
[2] Rebuild starting from the failed step
[3] Skip recipe
[4] Abort
```
During the check for config, git gives values of the fluendo-cerbero repo, not the build directory of libtool.
And when it comes to do any operation that needs the account's default identity, it fails.

**For the record:**
By the way, the current community upstream implementation doesn't do any more this nasty **except-pass** wrapping with beautiful `> /dev/null 2>&1` redirection in `cerbero.utils.git.init_directory()` which hides some real problems:
```
    try:
        shell.call('%s add --force -A .' % GIT, git_dir, logfile=logfile)
        shell.call('%s commit -m "Initial commit" > /dev/null 2>&1' % GIT,
            git_dir, logfile=logfile)
    except:
        pass
```

Going to contribute the same fix in the Community's repo.