### PR TITLE
Update emscripten to 3.1.68

### DIFF
--- a/cerbero/bootstrap/emscripten.py
+++ b/cerbero/bootstrap/emscripten.py
@@ -27,10 +27,10 @@ import os.path
 import shutil
 
 
-EMSDK_VERSION = '3.1.61'
+EMSDK_VERSION = '3.1.68'
 EMSDK_BUNDLE_EXT = '.tar.gz'
 EMSDK_BASE_URL = 'https://github.com/emscripten-core/emsdk/archive/refs/tags/%s' + EMSDK_BUNDLE_EXT
-EMSDK_CHECKSUMS = {'3.1.61' + EMSDK_BUNDLE_EXT: '51a4f6ec070147abe8f94546d8e18dde458d63f8c2927f94265ad49ef8431a1c'}
+EMSDK_CHECKSUMS = {'3.1.68' + EMSDK_BUNDLE_EXT: '97f21c32c0c1eecb963d19d1cacf58538086ce28eb28274993ab21d3673b5c29'}
 
 
 class EmscriptenToolchainBootstrapper(BootstrapperBase):


### PR DESCRIPTION
Rust version, 1.84.0, will use emsdk 3.1.68 and this unblocks issues with gst-plugins-rs