### PR TITLE
OCP-6055 update 'imp' module to 'importlib'

### DIFF
--- a/cerbero/bootstrap/site-patch.py
+++ b/cerbero/bootstrap/site-patch.py
@@ -25,7 +25,7 @@ def __boot():
                 break
         else:
             try:
-                import imp  # Avoid import loop in Python 3
+                import importlib as imp  # Avoid import loop in Python 3
                 stream, path, descr = imp.find_module('site', [item])
             except ImportError:
                 continue

--- a/cerbero/build/cookbook.py
+++ b/cerbero/build/cookbook.py
@@ -19,7 +19,7 @@
 from collections import defaultdict
 import os
 import pickle
-import imp
+import importlib as imp
 import traceback
 import shutil
 

--- a/cerbero/packages/packagesstore.py
+++ b/cerbero/packages/packagesstore.py
@@ -17,7 +17,7 @@
 # Boston, MA 02111-1307, USA.
 
 import os
-import imp
+import importlib as imp
 import traceback
 from collections import defaultdict
 


### PR DESCRIPTION
For Python 3.12+, 'imp' module is called 'importlib'. flu-plugins' CI was updated to 3.12, so it was breaking it.

Issue: OCP-6055