### PR TITLE
OCP-6055 update 'imp' module 

### DIFF
--- a/cerbero/bootstrap/site-patch.py
+++ b/cerbero/bootstrap/site-patch.py
@@ -25,15 +25,15 @@ def __boot():
                 break
         else:
             try:
-                import imp  # Avoid import loop in Python 3
-                stream, path, descr = imp.find_module('site', [item])
+                from cerbero.utils import _, imp_find_module, imp_load_module  # Avoid import loop in Python 3
+                stream, path, descr = imp_find_module('site', [item])
             except ImportError:
                 continue
             if stream is None:
                 continue
             try:
                 # This should actually reload the current module
-                imp.load_module('site', stream, path, descr)
+                imp_load_module('site', stream, path, descr)
             finally:
                 stream.close()
             break

--- a/cerbero/build/cookbook.py
+++ b/cerbero/build/cookbook.py
@@ -19,7 +19,6 @@
 from collections import defaultdict
 import os
 import pickle
-import imp
 import traceback
 import shutil
 
@@ -28,7 +27,7 @@ from cerbero.config import CONFIG_DIR, Platform, Architecture, Distro,\
 from cerbero.build.build import BuildType
 from cerbero.build.source import SourceType
 from cerbero.errors import FatalError, RecipeNotFoundError, InvalidRecipeError
-from cerbero.utils import _, shell, parse_file, run_until_complete
+from cerbero.utils import _, shell, parse_file, run_until_complete, imp_load_source
 from cerbero.utils import messages as m
 from cerbero.utils.manifest import Manifest
 from cerbero.build import recipe as crecipe
@@ -498,7 +497,7 @@ class CookBook (object):
         custom = None
         m_path = os.path.join(repo, 'custom.py')
         if os.path.exists(m_path):
-            custom = imp.load_source('custom', m_path)
+            custom = imp_load_source('custom', m_path)
             custom.GStreamer.using_manifest_force_git = self._config.manifest is not None
         for f in recipes_files:
             # Try to load the custom.py module located in the recipes dir

--- a/cerbero/packages/packagesstore.py
+++ b/cerbero/packages/packagesstore.py
@@ -17,7 +17,6 @@
 # Boston, MA 02111-1307, USA.
 
 import os
-import imp
 import traceback
 from collections import defaultdict
 
@@ -26,7 +25,7 @@ from cerbero.config import Platform, Architecture, Distro, DistroVersion,\
     License
 from cerbero.packages import package, PackageType
 from cerbero.errors import FatalError, PackageNotFoundError
-from cerbero.utils import _, shell, remove_list_duplicates, parse_file
+from cerbero.utils import _, shell, remove_list_duplicates, parse_file, imp_load_source
 from cerbero.utils import messages as m
 
 
@@ -190,7 +189,7 @@ class PackagesStore (object):
             custom = None
             m_path = os.path.join(repo, 'custom.py')
             if os.path.exists(m_path):
-                custom = imp.load_source('custom', m_path)
+                custom = imp_load_source('custom', m_path)
         except Exception as ex:
             # import traceback
             # traceback.print_exc()


### PR DESCRIPTION
'imp' module was removed in Python 3.12. flu-plugins' CI was updated to 3.12, so it was breaking it.

Issue: OCP-6055

See community reference PR: https://gitlab.freedesktop.org/gstreamer/cerbero/-/merge_requests/1300/diffs?commit_id=2a6ac79f5364966b6c66b1427841fa60db72172d#dbcb9b291b2eaf1946c39b5c2423829609dda1fe