### PR TITLE
Revert "build: use 'meson install' for meson recipes"

### DIFF
--- a/cerbero/build/build.py
+++ b/cerbero/build/build.py
@@ -671,7 +671,7 @@ class Meson (Build, ModifyEnvBase) :
         if not self.make:
             self.make = 'ninja -v -d keeprsp'
         if not self.make_install:
-            self.make_install = self.make + ' install --skip-subprojects'
+            self.make_install = self.make + ' install'
         if not self.make_uninstall:
             self.make_uninstall = self.make + ' uninstall'
         if not self.make_check:


### PR DESCRIPTION
This reverts commit ae2707a7a6d97f22d0b607a13ac940576ecf3dd5.

We'll add it again soon. Our CI is not prepare for this change yet.